### PR TITLE
feat(auth): signup page with validation account creation

### DIFF
--- a/Helpdesk/.kiro/specs/helpdesk-ticketing-system/design.md
+++ b/Helpdesk/.kiro/specs/helpdesk-ticketing-system/design.md
@@ -1,0 +1,310 @@
+# Design Document
+
+## Overview
+
+This design document outlines the transformation of the existing forum system into a comprehensive Helpdesk Ticketing and Support System. The system will maintain the current technical stack (HTML5, CSS3, Vanilla JavaScript, PHP, MySQL) while restructuring the data model and user interface to support ticket-based customer support workflows.
+
+The design leverages the existing MVC-like structure with `app.php` as the main controller, view files in the `views/` directory, and action handlers in the `actions/` directory. The current authentication system and CSS framework will be extended to support the new helpdesk functionality.
+
+## Architecture
+
+### System Architecture
+The helpdesk system follows a traditional three-tier architecture:
+
+1. **Presentation Layer**: HTML5 views with CSS3 styling and Vanilla JavaScript for interactivity
+2. **Application Layer**: PHP scripts handling business logic and request routing
+3. **Data Layer**: MySQL database with normalized tables for tickets, users, and related entities
+
+### File Structure
+```
+/
+├── app.php                 # Main application controller
+├── connector.php           # Database connection configuration
+├── login.php              # User authentication
+├── signup.php             # User registration
+├── logout.php             # Session termination
+├── index.php              # Entry point (redirects to app.php)
+├── styles.css             # Main stylesheet
+├── actions/               # Server-side action handlers
+│   ├── create_ticket.php
+│   ├── update_ticket.php
+│   ├── add_reply.php
+│   ├── assign_ticket.php
+│   ├── update_status.php
+│   └── upload_file.php
+├── views/                 # UI view templates
+│   ├── dashboard.php      # Admin dashboard
+│   ├── tickets.php        # Ticket listing
+│   ├── ticket.php         # Individual ticket view
+│   ├── create_ticket.php  # Ticket creation form
+│   └── my_tickets.php     # Customer ticket history
+└── uploads/               # File attachment storage
+```
+
+### Request Flow
+1. User requests are routed through `app.php` based on the `view` parameter
+2. Authentication is checked via session variables
+3. Appropriate view file is included based on user role and requested action
+4. Form submissions are processed by action handlers in the `actions/` directory
+5. Database operations use prepared statements via the existing `connector.php`
+
+## Components and Interfaces
+
+### User Management Component
+**Purpose**: Handle user authentication, registration, and role management
+
+**Key Functions**:
+- User registration with role assignment (Customer/Admin)
+- Session-based authentication
+- Profile management
+- Role-based access control
+
+**Interfaces**:
+- `login.php`: Authentication form and processing
+- `signup.php`: Registration form with role selection
+- `views/edit_profile.php`: Profile management interface
+
+### Ticket Management Component
+**Purpose**: Core ticket lifecycle management
+
+**Key Functions**:
+- Ticket creation with categories and priorities
+- Status tracking (Open, In Progress, Resolved, Closed)
+- Assignment to support agents
+- File attachment handling
+
+**Interfaces**:
+- `views/create_ticket.php`: Ticket submission form
+- `views/ticket.php`: Individual ticket detail view
+- `views/tickets.php`: Ticket listing with filters
+- `actions/create_ticket.php`: Ticket creation handler
+- `actions/update_ticket.php`: Ticket modification handler
+
+### Communication Component
+**Purpose**: Handle replies, comments, and internal notes
+
+**Key Functions**:
+- Public replies visible to customers
+- Internal notes for admin collaboration
+- File attachments for replies
+- Chronological conversation threading
+
+**Interfaces**:
+- Reply forms embedded in ticket views
+- `actions/add_reply.php`: Reply processing handler
+- File upload integration
+
+### Dashboard Component
+**Purpose**: Provide administrative overview and metrics
+
+**Key Functions**:
+- Ticket statistics and metrics
+- Recent activity monitoring
+- Quick access to urgent tickets
+- Performance indicators
+
+**Interfaces**:
+- `views/dashboard.php`: Admin dashboard view
+- AJAX endpoints for real-time updates
+
+### Search and Filter Component
+**Purpose**: Enable efficient ticket discovery and management
+
+**Key Functions**:
+- Full-text search across tickets
+- Multi-criteria filtering
+- Pagination for large result sets
+- Saved search preferences
+
+**Interfaces**:
+- Search forms integrated into listing views
+- Filter controls with AJAX updates
+- Pagination controls
+
+## Data Models
+
+### Database Schema
+
+#### Users Table (Modified from existing)
+```sql
+CREATE TABLE users (
+    user_id INT PRIMARY KEY AUTO_INCREMENT,
+    username VARCHAR(100) NOT NULL UNIQUE,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL,
+    full_name VARCHAR(255) NOT NULL,
+    user_role ENUM('CUSTOMER', 'ADMIN') DEFAULT 'CUSTOMER',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+```
+
+#### Tickets Table (New)
+```sql
+CREATE TABLE tickets (
+    ticket_id INT PRIMARY KEY AUTO_INCREMENT,
+    title VARCHAR(255) NOT NULL,
+    description TEXT NOT NULL,
+    category ENUM('Technical', 'Billing', 'General') NOT NULL,
+    priority ENUM('Low', 'Medium', 'High', 'Urgent') DEFAULT 'Medium',
+    status ENUM('Open', 'In Progress', 'Resolved', 'Closed') DEFAULT 'Open',
+    customer_id INT NOT NULL,
+    assigned_to INT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    last_activity TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (customer_id) REFERENCES users(user_id),
+    FOREIGN KEY (assigned_to) REFERENCES users(user_id)
+);
+```
+
+#### Ticket Replies Table (New)
+```sql
+CREATE TABLE ticket_replies (
+    reply_id INT PRIMARY KEY AUTO_INCREMENT,
+    ticket_id INT NOT NULL,
+    author_id INT NOT NULL,
+    content TEXT NOT NULL,
+    is_internal BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (ticket_id) REFERENCES tickets(ticket_id) ON DELETE CASCADE,
+    FOREIGN KEY (author_id) REFERENCES users(user_id)
+);
+```
+
+#### File Attachments Table (New)
+```sql
+CREATE TABLE attachments (
+    attachment_id INT PRIMARY KEY AUTO_INCREMENT,
+    ticket_id INT NULL,
+    reply_id INT NULL,
+    filename VARCHAR(255) NOT NULL,
+    original_filename VARCHAR(255) NOT NULL,
+    file_size INT NOT NULL,
+    mime_type VARCHAR(100) NOT NULL,
+    uploaded_by INT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (ticket_id) REFERENCES tickets(ticket_id) ON DELETE CASCADE,
+    FOREIGN KEY (reply_id) REFERENCES ticket_replies(reply_id) ON DELETE CASCADE,
+    FOREIGN KEY (uploaded_by) REFERENCES users(user_id)
+);
+```
+
+#### Categories Table (New)
+```sql
+CREATE TABLE categories (
+    category_id INT PRIMARY KEY AUTO_INCREMENT,
+    name VARCHAR(100) NOT NULL UNIQUE,
+    description TEXT,
+    color_code VARCHAR(7) DEFAULT '#2E6DA4',
+    is_active BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+### Data Relationships
+- **Users** have many **Tickets** (as customers)
+- **Users** can be assigned many **Tickets** (as admins)
+- **Tickets** have many **Ticket Replies**
+- **Tickets** and **Ticket Replies** can have many **Attachments**
+- **Tickets** belong to one **Category**
+
+### Data Validation Rules
+- Email addresses must be unique and valid format
+- Passwords must be at least 6 characters
+- Ticket titles are required and limited to 255 characters
+- File uploads limited to 5MB and specific MIME types
+- Status transitions follow business rules (e.g., only admins can close tickets)
+
+## Error Handling
+
+### Client-Side Validation
+- Form validation using HTML5 attributes and JavaScript
+- Real-time feedback for invalid inputs
+- File upload validation (size, type, count)
+- Required field highlighting
+
+### Server-Side Validation
+- Input sanitization and validation for all form submissions
+- SQL injection prevention using prepared statements
+- XSS prevention through output escaping
+- File upload security checks
+
+### Error Response Strategy
+- User-friendly error messages for validation failures
+- Detailed logging for system errors
+- Graceful degradation for JavaScript failures
+- Consistent error page templates
+
+### Database Error Handling
+- Connection failure recovery
+- Transaction rollback for data integrity
+- Constraint violation handling
+- Deadlock detection and retry logic
+
+## Testing Strategy
+
+### Unit Testing Approach
+- PHP unit tests for core business logic functions
+- Database operation testing with test fixtures
+- Input validation testing with edge cases
+- File upload functionality testing
+
+### Integration Testing
+- End-to-end ticket creation and resolution workflows
+- User authentication and authorization flows
+- File attachment upload and download processes
+- Email notification delivery (if implemented)
+
+### User Acceptance Testing
+- Customer ticket submission and tracking scenarios
+- Admin ticket management and assignment workflows
+- Search and filtering functionality validation
+- Mobile responsiveness testing
+
+### Security Testing
+- SQL injection vulnerability testing
+- XSS attack prevention validation
+- File upload security testing
+- Session management security verification
+- Access control testing for different user roles
+
+### Performance Testing
+- Database query optimization validation
+- File upload performance testing
+- Concurrent user load testing
+- Search functionality performance validation
+
+### Browser Compatibility Testing
+- Cross-browser JavaScript functionality
+- CSS rendering consistency
+- Mobile device compatibility
+- Accessibility compliance testing
+
+## UI/UX Design Considerations
+
+### Design Principles
+- Maintain consistency with existing forum design patterns
+- Prioritize clarity and ease of use for support workflows
+- Implement responsive design for mobile accessibility
+- Use color coding for ticket priorities and statuses
+
+### Navigation Structure
+- Dashboard-centric design for admins
+- Simplified ticket-focused navigation for customers
+- Breadcrumb navigation for deep ticket views
+- Quick action buttons for common tasks
+
+### Visual Hierarchy
+- Clear distinction between customer and admin interfaces
+- Priority-based visual indicators for tickets
+- Status-based color coding throughout the system
+- Consistent typography and spacing
+
+### Accessibility Features
+- Semantic HTML markup for screen readers
+- Keyboard navigation support
+- High contrast color schemes
+- Alt text for all images and icons
+
+This design provides a comprehensive foundation for transforming the existing forum system into a professional helpdesk ticketing system while maintaining the current technical architecture and complexity level.

--- a/Helpdesk/.kiro/specs/helpdesk-ticketing-system/requirements.md
+++ b/Helpdesk/.kiro/specs/helpdesk-ticketing-system/requirements.md
@@ -1,0 +1,152 @@
+# Requirements Document
+
+## Introduction
+
+This document outlines the requirements for transforming the existing forum system into a comprehensive Helpdesk Ticketing and Support System. The system will enable users to submit support tickets, track their progress, and allow administrators to manage and resolve customer issues efficiently. The system will maintain the same technical stack (HTML5, CSS3, Vanilla JavaScript, PHP, MySQL) and complexity level as the current forum project.
+
+## Requirements
+
+### Requirement 1
+
+**User Story:** As a customer, I want to register and login to the system, so that I can submit and track my support tickets securely.
+
+#### Acceptance Criteria
+
+1. WHEN a new user visits the registration page THEN the system SHALL display a form with fields for username, email, password, and full name
+2. WHEN a user submits valid registration data THEN the system SHALL create a new user account with default "customer" role
+3. WHEN a user attempts to register with an existing username or email THEN the system SHALL display an appropriate error message
+4. WHEN a registered user enters valid credentials THEN the system SHALL authenticate them and create a session
+5. WHEN an invalid login attempt is made THEN the system SHALL display an error message without revealing whether username or password was incorrect
+
+### Requirement 2
+
+**User Story:** As a customer, I want to submit support tickets with different categories, so that my issues can be properly classified and routed to the appropriate support team.
+
+#### Acceptance Criteria
+
+1. WHEN a logged-in customer accesses the ticket creation form THEN the system SHALL display fields for title, description, category, and priority
+2. WHEN creating a ticket THEN the system SHALL provide category options: Technical, Billing, and General
+3. WHEN creating a ticket THEN the system SHALL provide priority options: Low, Medium, High, and Urgent
+4. WHEN a customer submits a valid ticket THEN the system SHALL create the ticket with status "Open" and assign a unique ticket ID
+5. WHEN a ticket is created THEN the system SHALL automatically set the creation timestamp and assign it to the submitting user
+6. IF any required fields are missing THEN the system SHALL display validation errors and prevent submission
+
+### Requirement 3
+
+**User Story:** As a customer, I want to view my ticket history and current status, so that I can track the progress of my support requests.
+
+#### Acceptance Criteria
+
+1. WHEN a customer accesses their ticket dashboard THEN the system SHALL display all tickets they have submitted
+2. WHEN viewing ticket list THEN the system SHALL show ticket ID, title, category, status, priority, and creation date
+3. WHEN a customer clicks on a ticket THEN the system SHALL display full ticket details including all replies and status history
+4. WHEN viewing tickets THEN the system SHALL provide filtering options by status and category
+5. WHEN no tickets exist THEN the system SHALL display a message encouraging the user to submit their first ticket
+
+### Requirement 4
+
+**User Story:** As a customer, I want to add comments and replies to my existing tickets, so that I can provide additional information or respond to support agent questions.
+
+#### Acceptance Criteria
+
+1. WHEN viewing a ticket detail page THEN the system SHALL display all previous replies in chronological order
+2. WHEN a customer wants to reply THEN the system SHALL provide a text area for entering their response
+3. WHEN a customer submits a reply THEN the system SHALL add the reply to the ticket and update the last activity timestamp
+4. WHEN a reply is added THEN the system SHALL automatically change ticket status from "Resolved" back to "Open" if applicable
+5. IF a ticket is closed THEN the system SHALL prevent customers from adding new replies
+
+### Requirement 5
+
+**User Story:** As a customer, I want to attach files to my tickets, so that I can provide screenshots, documents, or other relevant materials to help resolve my issue.
+
+#### Acceptance Criteria
+
+1. WHEN creating or replying to a ticket THEN the system SHALL provide a file upload option
+2. WHEN uploading files THEN the system SHALL accept common formats: images (jpg, png, gif), documents (pdf, doc, txt), and limit file size to 5MB
+3. WHEN a file is uploaded THEN the system SHALL store it securely and associate it with the ticket or reply
+4. WHEN viewing tickets THEN the system SHALL display attached files as downloadable links
+5. IF an invalid file type or size is uploaded THEN the system SHALL display an error message and prevent upload
+
+### Requirement 6
+
+**User Story:** As an administrator, I want to access a comprehensive dashboard, so that I can monitor ticket volume, response times, and overall system performance.
+
+#### Acceptance Criteria
+
+1. WHEN an admin logs in THEN the system SHALL display a dashboard with key metrics and statistics
+2. WHEN viewing the dashboard THEN the system SHALL show total tickets, open tickets, resolved tickets, and average response time
+3. WHEN on the dashboard THEN the system SHALL display recent ticket activity and tickets requiring attention
+4. WHEN viewing statistics THEN the system SHALL provide breakdown by category and priority level
+5. WHEN accessing the dashboard THEN the system SHALL show tickets assigned to the current admin user
+
+### Requirement 7
+
+**User Story:** As an administrator, I want to view and filter all tickets in the system, so that I can efficiently manage the support workload and prioritize urgent issues.
+
+#### Acceptance Criteria
+
+1. WHEN an admin accesses the ticket management page THEN the system SHALL display all tickets in the system
+2. WHEN viewing all tickets THEN the system SHALL provide filtering options by status, category, priority, and date range
+3. WHEN viewing tickets THEN the system SHALL implement pagination to handle large numbers of tickets
+4. WHEN filtering tickets THEN the system SHALL update the display in real-time without page refresh
+5. WHEN viewing ticket list THEN the system SHALL show assignee information and last activity date
+
+### Requirement 8
+
+**User Story:** As an administrator, I want to assign tickets to support agents, so that workload can be distributed effectively and customers receive specialized help.
+
+#### Acceptance Criteria
+
+1. WHEN viewing a ticket THEN the system SHALL provide an option to assign it to any admin user
+2. WHEN assigning a ticket THEN the system SHALL update the assignee field and log the assignment action
+3. WHEN a ticket is assigned THEN the system SHALL automatically update the status to "In Progress" if it was "Open"
+4. WHEN viewing assigned tickets THEN the system SHALL clearly indicate which admin is responsible
+5. IF a ticket is reassigned THEN the system SHALL maintain a history of all assignment changes
+
+### Requirement 9
+
+**User Story:** As an administrator, I want to update ticket status throughout the resolution process, so that customers are informed of progress and the support workflow is properly managed.
+
+#### Acceptance Criteria
+
+1. WHEN managing a ticket THEN the system SHALL provide status options: Open, In Progress, Resolved, and Closed
+2. WHEN updating ticket status THEN the system SHALL log the change with timestamp and admin user
+3. WHEN a ticket is marked as "Resolved" THEN the system SHALL notify the customer and allow them to reopen if needed
+4. WHEN a ticket is marked as "Closed" THEN the system SHALL prevent further customer replies
+5. IF status is changed to "In Progress" THEN the system SHALL require the ticket to be assigned to an admin
+
+### Requirement 10
+
+**User Story:** As an administrator, I want to reply to tickets and add internal notes, so that I can communicate with customers and collaborate with other support agents.
+
+#### Acceptance Criteria
+
+1. WHEN replying to a ticket THEN the system SHALL provide options for public reply (visible to customer) or internal note (admin only)
+2. WHEN adding a public reply THEN the system SHALL notify the customer and update the ticket's last activity
+3. WHEN adding an internal note THEN the system SHALL only display it to admin users and mark it clearly as internal
+4. WHEN viewing ticket history THEN the system SHALL display all replies and notes in chronological order with clear attribution
+5. WHEN replying to a ticket THEN the system SHALL automatically update the ticket status to "In Progress" if it was "Open"
+
+### Requirement 11
+
+**User Story:** As a user, I want to search for tickets using keywords, so that I can quickly find specific tickets or related issues.
+
+#### Acceptance Criteria
+
+1. WHEN accessing the ticket interface THEN the system SHALL provide a search box for entering keywords
+2. WHEN performing a search THEN the system SHALL look for matches in ticket titles, descriptions, and replies
+3. WHEN search results are displayed THEN the system SHALL highlight matching keywords and show relevance
+4. WHEN no results are found THEN the system SHALL display a helpful message suggesting search refinements
+5. IF user has appropriate permissions THEN the system SHALL only show tickets they are authorized to view
+
+### Requirement 12
+
+**User Story:** As a system administrator, I want proper security measures implemented, so that user data is protected and the system is resistant to common attacks.
+
+#### Acceptance Criteria
+
+1. WHEN any database query is executed THEN the system SHALL use prepared statements to prevent SQL injection
+2. WHEN users submit forms THEN the system SHALL validate input both client-side and server-side
+3. WHEN handling user sessions THEN the system SHALL implement secure session management with appropriate timeouts
+4. WHEN displaying user content THEN the system SHALL sanitize output to prevent XSS attacks
+5. WHEN users access restricted areas THEN the system SHALL verify proper authentication and authorization

--- a/Helpdesk/.kiro/specs/helpdesk-ticketing-system/tasks.md
+++ b/Helpdesk/.kiro/specs/helpdesk-ticketing-system/tasks.md
@@ -1,0 +1,106 @@
+# Implementation Plan
+
+- [x] 1. Set up database schema and core data structures
+  - Create new database schema with tickets, ticket_replies, attachments, and categories tables
+  - Modify existing users table to include email, full_name, and user_role fields
+  - Insert default categories (Technical, Billing, General) and sample data
+  - Update connector.php to use new database name if needed
+  - _Requirements: 1.1, 1.2, 2.1, 2.2, 12.1_
+
+- [x] 2. Implement enhanced user authentication and registration system
+  - Modify signup.php to include email, full_name fields and default to CUSTOMER role
+  - Update login.php to support email or username authentication
+  - Add server-side validation for email format and uniqueness
+  - Update session management to include user_role information
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 12.2, 12.3_
+
+- [x] 3. Create ticket submission functionality
+  - Build views/create_ticket.php with form for title, description, category, and priority
+  - Implement actions/create_ticket.php to handle ticket creation with validation
+  - Add client-side form validation using JavaScript
+  - Create file upload capability for ticket attachments
+  - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 5.1, 5.2, 5.3, 12.2_
+
+- [x] 4. Implement customer ticket dashboard and history
+  - Create views/my_tickets.php to display customer's personal tickets
+  - Add filtering by status and category for customer tickets
+  - Implement search functionality within customer's tickets
+  - Add pagination for ticket lists
+  - _Requirements: 3.1, 3.2, 3.4, 3.5, 11.1, 11.2, 11.5_
+
+- [-] 5. Build individual ticket detail view and reply system
+  - Create views/ticket.php to display full ticket details with reply history
+  - Implement actions/add_reply.php for customer replies to tickets
+  - Add file attachment support for replies
+  - Implement automatic status change from Resolved to Open when customer replies
+  - _Requirements: 3.3, 4.1, 4.2, 4.3, 4.4, 4.5, 5.4, 5.5_
+
+- [ ] 6. Create admin dashboard with statistics and overview
+  - Build views/dashboard.php with ticket metrics and statistics
+  - Display total tickets, open tickets, resolved tickets, and average response time
+  - Show recent ticket activity and tickets requiring attention
+  - Add breakdown by category and priority level
+  - _Requirements: 6.1, 6.2, 6.3, 6.4, 6.5_
+
+- [ ] 7. Implement admin ticket management interface
+  - Create admin version of views/tickets.php with all system tickets
+  - Add filtering options by status, category, priority, and date range
+  - Implement search functionality across all tickets
+  - Add pagination and sorting capabilities for large ticket lists
+  - _Requirements: 7.1, 7.2, 7.3, 7.4, 7.5, 11.1, 11.2, 11.3, 11.4_
+
+- [ ] 8. Build ticket assignment and status management system
+  - Implement actions/assign_ticket.php for assigning tickets to admin users
+  - Create actions/update_status.php for changing ticket status
+  - Add automatic status change to "In Progress" when ticket is assigned
+  - Implement assignment history tracking and logging
+  - _Requirements: 8.1, 8.2, 8.3, 8.4, 8.5, 9.1, 9.2, 9.3, 9.4, 9.5_
+
+- [ ] 9. Implement admin reply system with internal notes
+  - Extend actions/add_reply.php to support public replies and internal notes
+  - Add UI controls in ticket view to distinguish between public and internal responses
+  - Implement proper visibility controls so customers only see public replies
+  - Add automatic status updates when admins reply to tickets
+  - _Requirements: 10.1, 10.2, 10.3, 10.4, 10.5_
+
+- [ ] 10. Create file attachment system
+  - Implement actions/upload_file.php with security validation
+  - Create uploads directory with proper permissions and security
+  - Add file type and size validation (5MB limit, specific MIME types)
+  - Implement secure file download with access control
+  - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5_
+
+- [ ] 11. Update navigation and user interface
+  - Modify app.php navigation to include Dashboard, My Tickets, and Create Ticket links
+  - Update CSS styles to support ticket priority and status color coding
+  - Add responsive design elements for mobile ticket management
+  - Implement role-based navigation (different menus for customers vs admins)
+  - _Requirements: 6.1, 7.1, 3.1, 2.1_
+
+- [ ] 12. Implement comprehensive search functionality
+  - Create search functionality that looks through ticket titles, descriptions, and replies
+  - Add search result highlighting and relevance scoring
+  - Implement search filters and advanced search options
+  - Add search suggestions and auto-complete functionality
+  - _Requirements: 11.1, 11.2, 11.3, 11.4, 11.5_
+
+- [ ] 13. Add security enhancements and validation
+  - Implement comprehensive input sanitization for all forms
+  - Add CSRF protection tokens to all forms
+  - Implement proper access control checks for all admin functions
+  - Add rate limiting for ticket submission to prevent spam
+  - _Requirements: 12.1, 12.2, 12.3, 12.4, 12.5_
+
+- [ ] 14. Create comprehensive test suite
+  - Write unit tests for ticket creation, assignment, and status updates
+  - Create integration tests for complete ticket workflows
+  - Implement security tests for SQL injection and XSS prevention
+  - Add performance tests for search and filtering functionality
+  - _Requirements: All requirements validation_
+
+- [ ] 15. Final integration and cleanup
+  - Remove old forum-specific code and database tables
+  - Update index.php to redirect to appropriate dashboard based on user role
+  - Add error handling and user feedback throughout the application
+  - Implement proper logging for admin actions and system events
+  - _Requirements: All requirements integration_

--- a/Helpdesk/README.md
+++ b/Helpdesk/README.md
@@ -1,0 +1,87 @@
+# Community Bulletin & Forum
+
+## Overview
+
+Community Bulletin & Forum is a PHP-based platform for community interaction and information sharing. It allows community members to create bulletin posts, start forum discussions, and engage in conversations across different categories.
+
+## Features
+
+- Create bulletin posts for announcements, events, and marketplace items
+- Start and participate in forum discussions
+- Organize content by categories (General, Events, Marketplace, Discussions)
+- User authentication and profile management
+- Admin panel for content and user management
+- Reply system for forum topics
+- Simple and clean community-focused interface
+
+## Getting Started
+
+### Prerequisites
+
+- PHP 7.0 or higher
+- A web server (e.g., Apache, Nginx)
+- MySQL or compatible database (if using database features)
+
+### Installation
+
+1. **Download or clone the repository:**
+   - Download the project files to your web server directory
+   - Ensure all files are in the correct structure as shown in the File Structure section
+2. **Copy files to your web server directory.**
+
+3. **Configure database connection:**
+   - Create a `connector.php` file in the project root with the following content:
+     ```php
+     <?php
+
+     $dbServerName = "localhost";
+     $dbUserName = "root";
+     $dbPassword = "";
+     $dbName = "community_bulletin_db";
+
+     $conn = mysqli_connect($dbServerName, $dbUserName, $dbPassword, $dbName);
+
+     if ($conn->connect_error) {
+         die("Connection Failed" . $conn->connect_error);
+     }
+     ?>
+     ```
+   - Update the database credentials in `connector.php` if your setup is different.
+
+4. **Set appropriate permissions:**
+   - Ensure the web server can write to any upload or cache directories if used.
+
+### Usage
+
+- Access the application via your web browser at `http://localhost/8000` or your server's URL.
+- Register as a community member to create posts and participate in discussions.
+- Admins can manage all content and users through the admin panel.
+
+## File Structure
+
+- `index.php` - Main entry point (redirects to community home)
+- `home/community.php` - Community bulletin and forum home page
+- `home/forum-topic.php` - Individual forum topic view with replies
+- `writer/` - Community member interface for creating and managing posts
+- `admin/` - Administrative interface for content and user management
+- `connector.php` - Database configuration file
+- `community_bulletin_db.sql` - Database schema
+- `.gitignore` - Git ignore rules
+
+## Categories
+
+The platform supports four main content categories:
+- **General**: Community announcements and general information
+- **Events**: Community events, meetings, and activities
+- **Marketplace**: Buy/sell/trade items within the community
+- **Discussions**: Open discussions and questions
+
+## Design Notes
+
+The platform uses a modern, image-free design with:
+- Gradient backgrounds instead of image dependencies
+- Category-based color coding for visual organization
+- Clean, text-focused content presentation
+- Responsive design that works on all devices
+
+

--- a/Helpdesk/actions/add_reply.php
+++ b/Helpdesk/actions/add_reply.php
@@ -1,0 +1,220 @@
+<?php
+// This file is actions/add_reply.php - Handle ticket reply submissions
+
+session_start();
+require '../connector.php';
+
+// Check if user is logged in
+if (!isset($_SESSION['user_id'])) {
+    header("Location: ../login.php");
+    exit();
+}
+
+// Check if this is a POST request
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    header("Location: ../app.php");
+    exit();
+}
+
+// Get and validate form data
+$ticket_id = intval($_POST['ticket_id'] ?? 0);
+$content = trim($_POST['content'] ?? '');
+$is_internal = ($_SESSION['user_role'] === 'ADMIN' && isset($_POST['is_internal'])) ? 1 : 0;
+
+// Validate required fields
+if (!$ticket_id || empty($content)) {
+    $_SESSION['error'] = "Ticket ID and reply content are required.";
+    header("Location: ../app.php?view=ticket&id=" . $ticket_id);
+    exit();
+}
+
+// Verify ticket exists and user has permission to reply
+$ticket_sql = "SELECT ticket_id, customer_id, status FROM tickets WHERE ticket_id = ?";
+$ticket_stmt = $conn->prepare($ticket_sql);
+$ticket_stmt->bind_param('i', $ticket_id);
+$ticket_stmt->execute();
+$ticket_result = $ticket_stmt->get_result();
+
+if ($ticket_result->num_rows === 0) {
+    $_SESSION['error'] = "Ticket not found.";
+    header("Location: ../app.php");
+    exit();
+}
+
+$ticket = $ticket_result->fetch_assoc();
+
+// Check permissions
+$can_reply = false;
+if ($_SESSION['user_role'] === 'ADMIN') {
+    $can_reply = true; // Admins can reply to any ticket
+} elseif ($_SESSION['user_role'] === 'CUSTOMER' && $ticket['customer_id'] == $_SESSION['user_id']) {
+    $can_reply = true; // Customers can only reply to their own tickets
+}
+
+if (!$can_reply) {
+    $_SESSION['error'] = "You do not have permission to reply to this ticket.";
+    header("Location: ../app.php");
+    exit();
+}
+
+// Check if ticket is closed
+if ($ticket['status'] === 'Closed') {
+    $_SESSION['error'] = "Cannot reply to a closed ticket.";
+    header("Location: ../app.php?view=ticket&id=" . $ticket_id);
+    exit();
+}
+
+// Handle file upload if present
+$attachment_id = null;
+if (isset($_FILES['attachment']) && $_FILES['attachment']['error'] === UPLOAD_ERR_OK) {
+    $upload_result = handleFileUpload($_FILES['attachment'], $ticket_id, null);
+    if ($upload_result['success']) {
+        $attachment_id = $upload_result['attachment_id'];
+    } else {
+        $_SESSION['error'] = $upload_result['error'];
+        header("Location: ../app.php?view=ticket&id=" . $ticket_id);
+        exit();
+    }
+}
+
+try {
+    // Start transaction
+    $conn->begin_transaction();
+    
+    // Insert the reply
+    $reply_sql = "INSERT INTO ticket_replies (ticket_id, author_id, content, is_internal, created_at) 
+                  VALUES (?, ?, ?, ?, NOW())";
+    $reply_stmt = $conn->prepare($reply_sql);
+    $reply_stmt->bind_param('iisi', $ticket_id, $_SESSION['user_id'], $content, $is_internal);
+    
+    if (!$reply_stmt->execute()) {
+        throw new Exception("Failed to insert reply");
+    }
+    
+    $reply_id = $conn->insert_id;
+    
+    // Update attachment with reply_id if file was uploaded
+    if ($attachment_id) {
+        $update_attachment_sql = "UPDATE attachments SET reply_id = ? WHERE attachment_id = ?";
+        $update_attachment_stmt = $conn->prepare($update_attachment_sql);
+        $update_attachment_stmt->bind_param('ii', $reply_id, $attachment_id);
+        $update_attachment_stmt->execute();
+    }
+    
+    // Update ticket's last_activity timestamp
+    $update_ticket_sql = "UPDATE tickets SET last_activity = NOW()";
+    
+    // Handle status changes based on business rules
+    $new_status = null;
+    if ($_SESSION['user_role'] === 'CUSTOMER') {
+        // If customer replies to a resolved ticket, reopen it
+        if ($ticket['status'] === 'Resolved') {
+            $new_status = 'Open';
+            $update_ticket_sql = "UPDATE tickets SET last_activity = NOW(), status = 'Open'";
+        }
+    } elseif ($_SESSION['user_role'] === 'ADMIN' && !$is_internal) {
+        // If admin makes a public reply to an open ticket, mark as in progress
+        if ($ticket['status'] === 'Open') {
+            $new_status = 'In Progress';
+            $update_ticket_sql = "UPDATE tickets SET last_activity = NOW(), status = 'In Progress'";
+        }
+    }
+    
+    $update_ticket_sql .= " WHERE ticket_id = ?";
+    $update_ticket_stmt = $conn->prepare($update_ticket_sql);
+    $update_ticket_stmt->bind_param('i', $ticket_id);
+    
+    if (!$update_ticket_stmt->execute()) {
+        throw new Exception("Failed to update ticket");
+    }
+    
+    // Commit transaction
+    $conn->commit();
+    
+    // Set success message
+    $_SESSION['success'] = "Reply added successfully.";
+    if ($new_status) {
+        $_SESSION['success'] .= " Ticket status updated to " . $new_status . ".";
+    }
+    
+} catch (Exception $e) {
+    // Rollback transaction on error
+    $conn->rollback();
+    $_SESSION['error'] = "Failed to add reply. Please try again.";
+}
+
+// Redirect back to ticket
+header("Location: ../app.php?view=ticket&id=" . $ticket_id);
+exit();
+
+/**
+ * Handle file upload with validation and security checks
+ */
+function handleFileUpload($file, $ticket_id, $reply_id) {
+    global $conn;
+    
+    // Validate file upload
+    if ($file['error'] !== UPLOAD_ERR_OK) {
+        return ['success' => false, 'error' => 'File upload failed.'];
+    }
+    
+    // Check file size (5MB limit)
+    $max_size = 5 * 1024 * 1024; // 5MB in bytes
+    if ($file['size'] > $max_size) {
+        return ['success' => false, 'error' => 'File size exceeds 5MB limit.'];
+    }
+    
+    // Get file info
+    $original_filename = $file['name'];
+    $file_size = $file['size'];
+    $temp_path = $file['tmp_name'];
+    
+    // Validate file type
+    $allowed_types = [
+        'image/jpeg', 'image/jpg', 'image/png', 'image/gif',
+        'application/pdf',
+        'application/msword',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'text/plain'
+    ];
+    
+    $finfo = finfo_open(FILEINFO_MIME_TYPE);
+    $mime_type = finfo_file($finfo, $temp_path);
+    finfo_close($finfo);
+    
+    if (!in_array($mime_type, $allowed_types)) {
+        return ['success' => false, 'error' => 'File type not allowed. Please upload images, PDF, Word documents, or text files only.'];
+    }
+    
+    // Generate unique filename
+    $file_extension = pathinfo($original_filename, PATHINFO_EXTENSION);
+    $unique_filename = uniqid('attachment_') . '.' . $file_extension;
+    
+    // Ensure uploads directory exists
+    $upload_dir = '../uploads/';
+    if (!is_dir($upload_dir)) {
+        mkdir($upload_dir, 0755, true);
+    }
+    
+    $destination_path = $upload_dir . $unique_filename;
+    
+    // Move uploaded file
+    if (!move_uploaded_file($temp_path, $destination_path)) {
+        return ['success' => false, 'error' => 'Failed to save uploaded file.'];
+    }
+    
+    // Insert attachment record
+    $attachment_sql = "INSERT INTO attachments (ticket_id, reply_id, filename, original_filename, file_size, mime_type, uploaded_by, created_at) 
+                       VALUES (?, ?, ?, ?, ?, ?, ?, NOW())";
+    $attachment_stmt = $conn->prepare($attachment_sql);
+    $attachment_stmt->bind_param('iissisi', $ticket_id, $reply_id, $unique_filename, $original_filename, $file_size, $mime_type, $_SESSION['user_id']);
+    
+    if (!$attachment_stmt->execute()) {
+        // Clean up uploaded file if database insert fails
+        unlink($destination_path);
+        return ['success' => false, 'error' => 'Failed to save attachment information.'];
+    }
+    
+    return ['success' => true, 'attachment_id' => $conn->insert_id];
+}
+?>

--- a/Helpdesk/actions/create_post.php
+++ b/Helpdesk/actions/create_post.php
@@ -1,0 +1,26 @@
+<?php
+// This file is actions/create_post.php
+
+session_start();
+require '../connector.php';
+
+if (isset($_SESSION['user_id']) && in_array($_SESSION['user_type'], ['ADMIN', 'MEMBER'])) {
+    $title = $_POST['title'];
+    $content = $_POST['content'];
+    $category = $_POST['category'];
+    if ($category === 'Other') {
+        $category = $_POST['new_category'];
+    }
+    $author_id = $_SESSION['user_id'];
+    // For simplicity, we'll hardcode post_type. This could be a form field.
+    $post_type = 'FORUM'; 
+
+    $sql = "INSERT INTO posts (title, content, author_id, post_type, category) VALUES (?, ?, ?, ?, ?)";
+    $stmt = $conn->prepare($sql);
+    $stmt->bind_param("ssiss", $title, $content, $author_id, $post_type, $category);
+    $stmt->execute();
+
+    // Redirect to the main posts view
+    header("Location: ../app.php?view=posts");
+    exit();
+}

--- a/Helpdesk/actions/create_ticket.php
+++ b/Helpdesk/actions/create_ticket.php
@@ -1,0 +1,205 @@
+<?php
+session_start();
+require '../connector.php';
+
+// Check if user is logged in and is a customer
+if (!isset($_SESSION['user_id']) || $_SESSION['user_role'] !== 'CUSTOMER') {
+    header("Location: ../login.php");
+    exit();
+}
+
+// Check if form was submitted via POST
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    header("Location: ../app.php?view=create_ticket");
+    exit();
+}
+
+// Sanitize and validate input data
+$title = trim($_POST['title'] ?? '');
+$category = trim($_POST['category'] ?? '');
+$priority = trim($_POST['priority'] ?? '');
+$description = trim($_POST['description'] ?? '');
+$customer_id = $_SESSION['user_id'];
+
+// Validation
+$errors = [];
+
+// Validate title
+if (empty($title)) {
+    $errors[] = 'Title is required';
+} elseif (strlen($title) < 5) {
+    $errors[] = 'Title must be at least 5 characters long';
+} elseif (strlen($title) > 255) {
+    $errors[] = 'Title must be less than 255 characters';
+}
+
+// Validate category
+$valid_categories = ['Technical', 'Billing', 'General'];
+if (empty($category) || !in_array($category, $valid_categories)) {
+    $errors[] = 'Please select a valid category';
+}
+
+// Validate priority
+$valid_priorities = ['Low', 'Medium', 'High', 'Urgent'];
+if (empty($priority) || !in_array($priority, $valid_priorities)) {
+    $errors[] = 'Please select a valid priority level';
+}
+
+// Validate description
+if (empty($description)) {
+    $errors[] = 'Description is required';
+} elseif (strlen($description) < 10) {
+    $errors[] = 'Description must be at least 10 characters long';
+}
+
+// If there are validation errors, redirect back with error
+if (!empty($errors)) {
+    header("Location: ../app.php?view=create_ticket&error=validation");
+    exit();
+}
+
+// Handle file uploads
+$uploaded_files = [];
+if (isset($_FILES['attachments']) && !empty($_FILES['attachments']['name'][0])) {
+    $upload_dir = '../uploads/';
+    
+    // Create uploads directory if it doesn't exist
+    if (!is_dir($upload_dir)) {
+        mkdir($upload_dir, 0755, true);
+    }
+    
+    $max_file_size = 5 * 1024 * 1024; // 5MB
+    $allowed_types = [
+        'image/jpeg', 'image/jpg', 'image/png', 'image/gif',
+        'application/pdf', 'application/msword',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'text/plain'
+    ];
+    
+    $file_count = count($_FILES['attachments']['name']);
+    
+    // Validate file count
+    if ($file_count > 5) {
+        header("Location: ../app.php?view=create_ticket&error=upload");
+        exit();
+    }
+    
+    for ($i = 0; $i < $file_count; $i++) {
+        if ($_FILES['attachments']['error'][$i] === UPLOAD_ERR_OK) {
+            $file_tmp = $_FILES['attachments']['tmp_name'][$i];
+            $file_name = $_FILES['attachments']['name'][$i];
+            $file_size = $_FILES['attachments']['size'][$i];
+            $file_type = $_FILES['attachments']['type'][$i];
+            
+            // Validate file size
+            if ($file_size > $max_file_size) {
+                header("Location: ../app.php?view=create_ticket&error=upload");
+                exit();
+            }
+            
+            // Validate file type
+            if (!in_array($file_type, $allowed_types)) {
+                header("Location: ../app.php?view=create_ticket&error=upload");
+                exit();
+            }
+            
+            // Generate unique filename
+            $file_extension = pathinfo($file_name, PATHINFO_EXTENSION);
+            $unique_filename = uniqid('ticket_', true) . '.' . $file_extension;
+            $file_path = $upload_dir . $unique_filename;
+            
+            // Move uploaded file
+            if (move_uploaded_file($file_tmp, $file_path)) {
+                $uploaded_files[] = [
+                    'filename' => $unique_filename,
+                    'original_filename' => $file_name,
+                    'file_size' => $file_size,
+                    'mime_type' => $file_type
+                ];
+            } else {
+                // Clean up any previously uploaded files on error
+                foreach ($uploaded_files as $uploaded_file) {
+                    unlink($upload_dir . $uploaded_file['filename']);
+                }
+                header("Location: ../app.php?view=create_ticket&error=upload");
+                exit();
+            }
+        }
+    }
+}
+
+// Begin database transaction
+mysqli_begin_transaction($conn);
+
+try {
+    // Insert ticket into database
+    $stmt = mysqli_prepare($conn, "INSERT INTO tickets (title, description, category, priority, customer_id, status, created_at, updated_at, last_activity) VALUES (?, ?, ?, ?, ?, 'Open', NOW(), NOW(), NOW())");
+    
+    if (!$stmt) {
+        throw new Exception("Prepare failed: " . mysqli_error($conn));
+    }
+    
+    mysqli_stmt_bind_param($stmt, "ssssi", $title, $description, $category, $priority, $customer_id);
+    
+    if (!mysqli_stmt_execute($stmt)) {
+        throw new Exception("Execute failed: " . mysqli_stmt_error($stmt));
+    }
+    
+    $ticket_id = mysqli_insert_id($conn);
+    mysqli_stmt_close($stmt);
+    
+    // Insert file attachments if any
+    if (!empty($uploaded_files)) {
+        $stmt = mysqli_prepare($conn, "INSERT INTO attachments (ticket_id, filename, original_filename, file_size, mime_type, uploaded_by, created_at) VALUES (?, ?, ?, ?, ?, ?, NOW())");
+        
+        if (!$stmt) {
+            throw new Exception("Prepare failed for attachments: " . mysqli_error($conn));
+        }
+        
+        foreach ($uploaded_files as $file) {
+            mysqli_stmt_bind_param($stmt, "issisi", 
+                $ticket_id, 
+                $file['filename'], 
+                $file['original_filename'], 
+                $file['file_size'], 
+                $file['mime_type'], 
+                $customer_id
+            );
+            
+            if (!mysqli_stmt_execute($stmt)) {
+                throw new Exception("Execute failed for attachment: " . mysqli_stmt_error($stmt));
+            }
+        }
+        
+        mysqli_stmt_close($stmt);
+    }
+    
+    // Commit transaction
+    mysqli_commit($conn);
+    
+    // Redirect to success page
+    header("Location: ../app.php?view=my_tickets&success=1&ticket_id=" . $ticket_id);
+    exit();
+    
+} catch (Exception $e) {
+    // Rollback transaction
+    mysqli_rollback($conn);
+    
+    // Clean up uploaded files on database error
+    foreach ($uploaded_files as $uploaded_file) {
+        $file_path = $upload_dir . $uploaded_file['filename'];
+        if (file_exists($file_path)) {
+            unlink($file_path);
+        }
+    }
+    
+    // Log error (in production, use proper logging)
+    error_log("Ticket creation error: " . $e->getMessage());
+    
+    // Redirect with error
+    header("Location: ../app.php?view=create_ticket&error=database");
+    exit();
+}
+
+mysqli_close($conn);
+?>

--- a/Helpdesk/actions/delete_post.php
+++ b/Helpdesk/actions/delete_post.php
@@ -1,0 +1,28 @@
+<?php
+// This file is actions/delete_post.php
+
+session_start();
+require '../connector.php';
+
+if (isset($_SESSION['user_id'])) {
+    $post_id = $_GET['id'] ?? 0;
+    if ($post_id > 0) {
+        // Check if user is author or admin
+        $sql_check = "SELECT author_id FROM posts WHERE post_id = ?";
+        $stmt_check = $conn->prepare($sql_check);
+        $stmt_check->bind_param("i", $post_id);
+        $stmt_check->execute();
+        $result_check = $stmt_check->get_result();
+        if ($result_check->num_rows == 1) {
+            $post_data = $result_check->fetch_assoc();
+            if ($post_data['author_id'] == $_SESSION['user_id'] || $_SESSION['user_type'] === 'ADMIN') {
+                $sql = "DELETE FROM posts WHERE post_id = ?";
+                $stmt = $conn->prepare($sql);
+                $stmt->bind_param("i", $post_id);
+                $stmt->execute();
+            }
+        }
+    }
+}
+header("Location: ../app.php?view=posts");
+exit();

--- a/Helpdesk/actions/delete_user.php
+++ b/Helpdesk/actions/delete_user.php
@@ -1,0 +1,17 @@
+<?php
+// This file is actions/delete_user.php
+
+session_start();
+require '../connector.php';
+
+if (isset($_SESSION['user_type']) && $_SESSION['user_type'] === 'ADMIN') {
+    $user_id = $_GET['id'] ?? 0;
+    if ($user_id > 0) {
+        $sql = "DELETE FROM user WHERE user_id = ?";
+        $stmt = $conn->prepare($sql);
+        $stmt->bind_param("i", $user_id);
+        $stmt->execute();
+    }
+}
+header("Location: ../app.php?view=users");
+exit();

--- a/Helpdesk/actions/download_file.php
+++ b/Helpdesk/actions/download_file.php
@@ -1,0 +1,75 @@
+<?php
+// This file is actions/download_file.php - Handle secure file downloads
+
+session_start();
+require '../connector.php';
+
+// Check if user is logged in
+if (!isset($_SESSION['user_id'])) {
+    header("Location: ../login.php");
+    exit();
+}
+
+// Get attachment ID
+$attachment_id = intval($_GET['id'] ?? 0);
+
+if (!$attachment_id) {
+    http_response_code(404);
+    echo "File not found.";
+    exit();
+}
+
+// Get attachment details and verify access permissions
+$sql = "SELECT a.*, t.customer_id 
+        FROM attachments a
+        LEFT JOIN tickets t ON a.ticket_id = t.ticket_id
+        WHERE a.attachment_id = ?";
+
+$stmt = $conn->prepare($sql);
+$stmt->bind_param('i', $attachment_id);
+$stmt->execute();
+$result = $stmt->get_result();
+
+if ($result->num_rows === 0) {
+    http_response_code(404);
+    echo "File not found.";
+    exit();
+}
+
+$attachment = $result->fetch_assoc();
+
+// Check access permissions
+$can_download = false;
+if ($_SESSION['user_role'] === 'ADMIN') {
+    $can_download = true; // Admins can download all files
+} elseif ($_SESSION['user_role'] === 'CUSTOMER' && $attachment['customer_id'] == $_SESSION['user_id']) {
+    $can_download = true; // Customers can only download files from their own tickets
+}
+
+if (!$can_download) {
+    http_response_code(403);
+    echo "Access denied.";
+    exit();
+}
+
+// Build file path
+$file_path = '../uploads/' . $attachment['filename'];
+
+// Check if file exists
+if (!file_exists($file_path)) {
+    http_response_code(404);
+    echo "File not found on server.";
+    exit();
+}
+
+// Set headers for file download
+header('Content-Type: ' . $attachment['mime_type']);
+header('Content-Disposition: attachment; filename="' . $attachment['original_filename'] . '"');
+header('Content-Length: ' . $attachment['file_size']);
+header('Cache-Control: no-cache, must-revalidate');
+header('Expires: 0');
+
+// Output file content
+readfile($file_path);
+exit();
+?>

--- a/Helpdesk/actions/update_post.php
+++ b/Helpdesk/actions/update_post.php
@@ -1,0 +1,33 @@
+<?php
+// This file is actions/update_post.php
+
+session_start();
+require '../connector.php';
+
+if (isset($_SESSION['user_id'])) {
+    $post_id = $_POST['post_id'];
+    $title = $_POST['title'];
+    $content = $_POST['content'];
+    $category = $_POST['category'];
+    if ($category === 'Other') {
+        $category = $_POST['new_category'];
+    }
+
+    // Check if user is author or admin
+    $sql_check = "SELECT author_id FROM posts WHERE post_id = ?";
+    $stmt_check = $conn->prepare($sql_check);
+    $stmt_check->bind_param("i", $post_id);
+    $stmt_check->execute();
+    $result_check = $stmt_check->get_result();
+    if ($result_check->num_rows == 1) {
+        $post_data = $result_check->fetch_assoc();
+        if ($post_data['author_id'] == $_SESSION['user_id'] || $_SESSION['user_type'] === 'ADMIN') {
+            $sql = "UPDATE posts SET title = ?, content = ?, category = ? WHERE post_id = ?";
+            $stmt = $conn->prepare($sql);
+            $stmt->bind_param("sssi", $title, $content, $category, $post_id);
+            $stmt->execute();
+        }
+    }
+}
+header("Location: ../app.php?view=post&id=" . $post_id);
+exit();

--- a/Helpdesk/actions/update_profile.php
+++ b/Helpdesk/actions/update_profile.php
@@ -1,0 +1,40 @@
+<?php
+// This file is actions/update_profile.php
+
+session_start();
+require '../connector.php';
+
+if (!isset($_SESSION['user_id'])) {
+    header("Location: ../login.php");
+    exit();
+}
+
+$user_id = $_SESSION['user_id'];
+$user_name = $_POST['user_name'];
+$password = $_POST['password'];
+
+// Start building the SQL query
+$sql = "UPDATE user SET user_name = ? ";
+$types = "s";
+$params = [$user_name];
+
+// Add password to update if provided
+if (!empty($password)) {
+    $sql .= ", pass = ? ";
+    $types .= "s";
+    $params[] = $password;
+}
+
+$sql .= " WHERE user_id = ?";
+$types .= "i";
+$params[] = $user_id;
+
+$stmt = $conn->prepare($sql);
+$stmt->bind_param($types, ...$params);
+$stmt->execute();
+
+// Update session username if it changed
+$_SESSION['user_name'] = $user_name;
+
+header("Location: ../app.php?view=edit_profile&status=success");
+exit();

--- a/Helpdesk/actions/update_user.php
+++ b/Helpdesk/actions/update_user.php
@@ -1,0 +1,18 @@
+<?php
+// This file is actions/update_user.php
+
+session_start();
+require '../connector.php';
+
+if (isset($_SESSION['user_type']) && $_SESSION['user_type'] === 'ADMIN') {
+    $user_id = $_POST['user_id'];
+    $user_name = $_POST['user_name'];
+    $user_type = $_POST['user_type'];
+
+    $sql = "UPDATE user SET user_name = ?, user_type = ? WHERE user_id = ?";
+    $stmt = $conn->prepare($sql);
+    $stmt->bind_param("ssi", $user_name, $user_type, $user_id);
+    $stmt->execute();
+}
+header("Location: ../app.php?view=users");
+exit();

--- a/Helpdesk/app.php
+++ b/Helpdesk/app.php
@@ -1,0 +1,120 @@
+
+<?php
+session_start();
+
+require 'connector.php';
+
+// Check if user is logged in
+if (!isset($_SESSION['user_id'])) {
+    header("Location: login.php");
+    exit();
+}
+
+// Set default view based on user role
+$default_view = ($_SESSION['user_role'] === 'ADMIN') ? 'dashboard' : 'my_tickets';
+$view = $_GET['view'] ?? $default_view;
+
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Helpdesk System</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+
+    <nav class="top-nav">
+        <div class="nav-container">
+            <a href="app.php" class="nav-brand">Helpdesk System</a>
+            <ul class="nav-links">
+                <?php if ($_SESSION['user_role'] === 'ADMIN'): ?>
+                    <li><a href="app.php?view=dashboard" class="<?= ($view === 'dashboard') ? 'active' : '' ?>">Dashboard</a></li>
+                    <li><a href="app.php?view=tickets" class="<?= ($view === 'tickets' || $view === 'ticket') ? 'active' : '' ?>">All Tickets</a></li>
+                    <li><a href="app.php?view=users" class="<?= ($view === 'users') ? 'active' : '' ?>">Manage Users</a></li>
+                <?php else: ?>
+                    <li><a href="app.php?view=my_tickets" class="<?= ($view === 'my_tickets' || $view === 'ticket') ? 'active' : '' ?>">My Tickets</a></li>
+                    <li><a href="app.php?view=create_ticket" class="<?= ($view === 'create_ticket') ? 'active' : '' ?>">Create Ticket</a></li>
+                <?php endif; ?>
+            </ul>
+            <ul class="nav-user">
+                <li><span class="user-welcome">Welcome, <?= htmlspecialchars($_SESSION['full_name']) ?></span></li>
+                <li><a href="app.php?view=edit_profile" class="<?= ($view === 'edit_profile') ? 'active' : '' ?>">Edit Profile</a></li>
+                <li><a href="logout.php" class="btn-signup">Logout</a></li>
+            </ul>
+        </div>
+    </nav>
+
+    <div class="main-container">
+        <div class="container">
+            <?php
+            // Based on the view parameter, include the corresponding content
+            switch ($view) {
+                case 'dashboard':
+                    if ($_SESSION['user_role'] === 'ADMIN') {
+                        echo "<h1>Admin Dashboard</h1><p>Dashboard functionality will be implemented in a future task.</p>";
+                    } else {
+                        header("Location: app.php?view=my_tickets");
+                        exit();
+                    }
+                    break;
+                case 'tickets':
+                    if ($_SESSION['user_role'] === 'ADMIN') {
+                        echo "<h1>All Tickets</h1><p>Ticket management functionality will be implemented in a future task.</p>";
+                    } else {
+                        header("Location: app.php?view=my_tickets");
+                        exit();
+                    }
+                    break;
+                case 'my_tickets':
+                    if ($_SESSION['user_role'] === 'CUSTOMER') {
+                        require 'views/my_tickets.php';
+                    } else {
+                        header("Location: app.php?view=dashboard");
+                        exit();
+                    }
+                    break;
+                case 'create_ticket':
+                    if ($_SESSION['user_role'] === 'CUSTOMER') {
+                        require 'views/create_ticket.php';
+                    } else {
+                        header("Location: app.php?view=dashboard");
+                        exit();
+                    }
+                    break;
+                case 'ticket':
+                    require 'views/ticket.php';
+                    break;
+                case 'users':
+                    if ($_SESSION['user_role'] === 'ADMIN') {
+                        require 'views/users.php';
+                    } else {
+                        header("Location: app.php?view=my_tickets");
+                        exit();
+                    }
+                    break;
+                case 'edit_user':
+                    if ($_SESSION['user_role'] === 'ADMIN') {
+                        require 'views/edit_user.php';
+                    } else {
+                        header("Location: app.php?view=my_tickets");
+                        exit();
+                    }
+                    break;
+                case 'edit_profile':
+                    require 'views/edit_profile.php';
+                    break;
+                default:
+                    // Redirect to appropriate default view
+                    $redirect_view = ($_SESSION['user_role'] === 'ADMIN') ? 'dashboard' : 'my_tickets';
+                    header("Location: app.php?view=" . $redirect_view);
+                    exit();
+                    break;
+            }
+            ?>
+        </div>
+    </div>
+
+</body>
+</html>

--- a/Helpdesk/connector.php
+++ b/Helpdesk/connector.php
@@ -1,0 +1,12 @@
+<?php
+
+$dbServerName = "localhost";
+$dbUserName = "root";
+$dbPassword = "deliquescent";
+$dbName = "helpdesk_db";
+
+$conn = mysqli_connect($dbServerName, $dbUserName, $dbPassword, $dbName);
+
+if ($conn->connect_error) {
+    die("Connection Failed" . $conn->connect_error);
+}

--- a/Helpdesk/helpdesk_db.sql
+++ b/Helpdesk/helpdesk_db.sql
@@ -1,0 +1,102 @@
+CREATE DATABASE IF NOT EXISTS helpdesk_db;
+
+USE helpdesk_db;
+
+-- Modified users table with additional fields for helpdesk system
+CREATE TABLE IF NOT EXISTS users (
+    user_id INT PRIMARY KEY AUTO_INCREMENT,
+    username VARCHAR(100) NOT NULL UNIQUE,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL,
+    full_name VARCHAR(255) NOT NULL,
+    user_role ENUM('CUSTOMER', 'ADMIN') DEFAULT 'CUSTOMER',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+-- Categories table for ticket classification
+CREATE TABLE IF NOT EXISTS categories (
+    category_id INT PRIMARY KEY AUTO_INCREMENT,
+    name VARCHAR(100) NOT NULL UNIQUE,
+    description TEXT,
+    color_code VARCHAR(7) DEFAULT '#2E6DA4',
+    is_active BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Main tickets table
+CREATE TABLE IF NOT EXISTS tickets (
+    ticket_id INT PRIMARY KEY AUTO_INCREMENT,
+    title VARCHAR(255) NOT NULL,
+    description TEXT NOT NULL,
+    category ENUM('Technical', 'Billing', 'General') NOT NULL,
+    priority ENUM('Low', 'Medium', 'High', 'Urgent') DEFAULT 'Medium',
+    status ENUM('Open', 'In Progress', 'Resolved', 'Closed') DEFAULT 'Open',
+    customer_id INT NOT NULL,
+    assigned_to INT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    last_activity TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (customer_id) REFERENCES users(user_id),
+    FOREIGN KEY (assigned_to) REFERENCES users(user_id)
+);
+
+-- Ticket replies table for communication
+CREATE TABLE IF NOT EXISTS ticket_replies (
+    reply_id INT PRIMARY KEY AUTO_INCREMENT,
+    ticket_id INT NOT NULL,
+    author_id INT NOT NULL,
+    content TEXT NOT NULL,
+    is_internal BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (ticket_id) REFERENCES tickets(ticket_id) ON DELETE CASCADE,
+    FOREIGN KEY (author_id) REFERENCES users(user_id)
+);
+
+-- File attachments table
+CREATE TABLE IF NOT EXISTS attachments (
+    attachment_id INT PRIMARY KEY AUTO_INCREMENT,
+    ticket_id INT NULL,
+    reply_id INT NULL,
+    filename VARCHAR(255) NOT NULL,
+    original_filename VARCHAR(255) NOT NULL,
+    file_size INT NOT NULL,
+    mime_type VARCHAR(100) NOT NULL,
+    uploaded_by INT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (ticket_id) REFERENCES tickets(ticket_id) ON DELETE CASCADE,
+    FOREIGN KEY (reply_id) REFERENCES ticket_replies(reply_id) ON DELETE CASCADE,
+    FOREIGN KEY (uploaded_by) REFERENCES users(user_id)
+);
+
+-- Insert default categories
+INSERT INTO categories (name, description, color_code) VALUES 
+('Technical', 'Technical support and troubleshooting issues', '#d9534f'),
+('Billing', 'Billing inquiries and payment-related issues', '#f0ad4e'),
+('General', 'General inquiries and other support requests', '#5cb85c');
+
+-- Insert default admin user
+INSERT INTO users (username, email, password, full_name, user_role) VALUES 
+('admin', 'admin@helpdesk.com', 'admin123', 'System Administrator', 'ADMIN');
+
+-- Insert sample customer user for testing
+INSERT INTO users (username, email, password, full_name, user_role) VALUES 
+('customer1', 'customer1@example.com', 'password123', 'John Customer', 'CUSTOMER'),
+('customer2', 'customer2@example.com', 'password123', 'Jane Smith', 'CUSTOMER');
+
+-- Insert sample support agent
+INSERT INTO users (username, email, password, full_name, user_role) VALUES 
+('support1', 'support1@helpdesk.com', 'support123', 'Support Agent One', 'ADMIN');
+
+-- Insert sample tickets for testing
+INSERT INTO tickets (title, description, category, priority, customer_id) VALUES 
+('Cannot login to my account', 'I am unable to login to my account. I keep getting an error message saying invalid credentials even though I am sure my password is correct.', 'Technical', 'High', 2),
+('Question about billing cycle', 'I would like to understand when my billing cycle starts and ends. Can someone please clarify this for me?', 'Billing', 'Medium', 3),
+('How to update my profile information', 'I need to update my contact information in my profile but cannot find where to do this. Please help.', 'General', 'Low', 2);
+
+-- Insert sample replies
+INSERT INTO ticket_replies (ticket_id, author_id, content, is_internal) VALUES 
+(1, 4, 'I have reviewed your account and can see the issue. Let me reset your password for you.', FALSE),
+(1, 4, 'Customer seems to have caps lock on when typing password', TRUE),
+(2, 4, 'Your billing cycle runs from the 1st to the last day of each month. You will receive your invoice on the 25th of each month.', FALSE),
+(3, 2, 'Thank you for the quick response! I found the profile section now.', FALSE);

--- a/Helpdesk/index.php
+++ b/Helpdesk/index.php
@@ -1,0 +1,4 @@
+<?php
+// Redirect to the main application page
+header("Location: app.php");
+exit();

--- a/Helpdesk/login.css
+++ b/Helpdesk/login.css
@@ -1,0 +1,84 @@
+
+:root {
+    --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    --bg-color: #FFFFFF;
+    --border-color: #E5E5E5;
+    --text-color: #333333;
+    --text-secondary-color: #888888;
+    --accent-color: #2E6DA4;
+}
+
+body {
+    font-family: var(--font-sans);
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    margin: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+}
+
+.login-container {
+    width: 320px;
+    padding: 40px;
+    background-color: #fff;
+    border-radius: 8px;
+    border: 1px solid var(--border-color);
+}
+
+h1 {
+    text-align: center;
+    font-size: 1.5em;
+    margin-bottom: 20px;
+}
+
+.form-group {
+    margin-bottom: 15px;
+}
+
+label {
+    display: block;
+    margin-bottom: 5px;
+    font-weight: 500;
+    color: var(--text-secondary-color);
+}
+
+input[type="text"], input[type="password"] {
+    width: 100%;
+    padding: 10px;
+    border: 1px solid var(--border-color);
+    border-radius: 5px;
+    box-sizing: border-box; /* Important */
+}
+
+button {
+    width: 100%;
+    padding: 10px;
+    background-color: var(--accent-color);
+    color: white;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 1em;
+}
+
+button:hover {
+    background-color: #204d74;
+}
+
+.message {
+    text-align: center;
+    margin-bottom: 15px;
+    color: red;
+}
+
+.signup-link {
+    text-align: center;
+    margin-top: 20px;
+}
+
+.signup-link a {
+    color: var(--accent-color);
+    text-decoration: none;
+}

--- a/Helpdesk/login.php
+++ b/Helpdesk/login.php
@@ -1,0 +1,80 @@
+
+<?php
+session_start();
+
+// If user is already logged in, redirect to app.php
+if (isset($_SESSION['user_id'])) {
+    header("Location: app.php");
+    exit();
+}
+
+require 'connector.php';
+
+$message = '';
+
+if ($_SERVER["REQUEST_METHOD"] == "POST") {
+    $login_input = trim($_POST['login_input']);
+    $password = $_POST['password'];
+
+    // Check if input is email or username
+    $is_email = filter_var($login_input, FILTER_VALIDATE_EMAIL);
+    
+    if ($is_email) {
+        // Login with email
+        $sql = "SELECT * FROM users WHERE email = ? AND password = ?";
+    } else {
+        // Login with username
+        $sql = "SELECT * FROM users WHERE username = ? AND password = ?";
+    }
+    
+    $stmt = $conn->prepare($sql);
+    $stmt->bind_param("ss", $login_input, $password);
+    $stmt->execute();
+    $result = $stmt->get_result();
+
+    if ($result->num_rows == 1) {
+        $user = $result->fetch_assoc();
+        $_SESSION['user_id'] = $user['user_id'];
+        $_SESSION['username'] = $user['username'];
+        $_SESSION['user_role'] = $user['user_role'];
+        $_SESSION['full_name'] = $user['full_name'];
+        $_SESSION['email'] = $user['email'];
+        header("Location: app.php");
+        exit();
+    } else {
+        $message = "Invalid credentials";
+    }
+}
+?>
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Login - Helpdesk</title>
+    <link rel="stylesheet" href="login.css">
+</head>
+<body>
+    <div class="login-container">
+        <h1>Helpdesk Login</h1>
+        <?php if ($message): ?>
+            <p class="message"><?= $message ?></p>
+        <?php endif; ?>
+        <form action="login.php" method="post">
+            <div class="form-group">
+                <label for="login_input">Username or Email</label>
+                <input type="text" id="login_input" name="login_input" required>
+            </div>
+            <div class="form-group">
+                <label for="password">Password</label>
+                <input type="password" id="password" name="password" required>
+            </div>
+            <button type="submit">Login</button>
+        </form>
+        <div class="signup-link">
+            <p>Don't have an account? <a href="signup.php">Sign up</a></p>
+        </div>
+    </div>
+</body>
+</html>

--- a/Helpdesk/logout.php
+++ b/Helpdesk/logout.php
@@ -1,0 +1,6 @@
+<?php
+session_start();
+session_unset();
+session_destroy();
+header("Location: index.php");
+exit();

--- a/Helpdesk/notion_forum_db.sql
+++ b/Helpdesk/notion_forum_db.sql
@@ -1,0 +1,52 @@
+CREATE DATABASE IF NOT EXISTS forum_db;
+
+USE forum_db;
+
+CREATE TABLE IF NOT EXISTS user (
+    user_id INT PRIMARY KEY NOT NULL AUTO_INCREMENT,
+    user_name VARCHAR(100) NOT NULL UNIQUE,
+    pass VARCHAR(100) NOT NULL,
+    user_type VARCHAR(20)
+);
+
+CREATE TABLE IF NOT EXISTS posts (
+    post_id INT PRIMARY KEY AUTO_INCREMENT,
+    title TEXT NOT NULL,
+    content TEXT NOT NULL,
+    post_type ENUM('BULLETIN', 'FORUM') NOT NULL,
+    category VARCHAR(20) NOT NULL,
+    img_name TEXT,
+    author_id INT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (author_id) REFERENCES user(user_id)
+);
+
+CREATE TABLE IF NOT EXISTS replies (
+    reply_id INT PRIMARY KEY AUTO_INCREMENT,
+    post_id INT NOT NULL,
+    content TEXT NOT NULL,
+    author_id INT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (post_id) REFERENCES posts(post_id) ON DELETE CASCADE,
+    FOREIGN KEY (author_id) REFERENCES user(user_id)
+);
+
+-- Insert default admin user
+INSERT INTO user (user_name, pass, user_type) VALUES ('uoc', 'uoc', 'ADMIN');
+
+-- Insert sample member user for testing
+INSERT INTO user (user_name, pass, user_type) VALUES ('testuser', 'password', 'MEMBER');
+
+-- Insert sample bulletin posts
+INSERT INTO posts (title, content, post_type, category, author_id) VALUES 
+('Welcome to the Community Bulletin', 'This is our new community bulletin system where you can share announcements and participate in discussions.', 'BULLETIN', 'General', 1),
+('Upcoming Community Event', 'Join us for our monthly community gathering this Saturday at 2 PM in the main hall.', 'BULLETIN', 'Events', 1);
+
+-- Insert sample forum post
+INSERT INTO posts (title, content, post_type, category, author_id) VALUES 
+('General Discussion: Community Guidelines', 'Let us discuss what guidelines we should have for our community forum. Please share your thoughts!', 'FORUM', 'Discussions', 1);
+
+-- Insert sample reply
+INSERT INTO replies (post_id, content, author_id) VALUES 
+(3, 'I think we should keep discussions respectful and on-topic. What do others think?', 2);

--- a/Helpdesk/signup.php
+++ b/Helpdesk/signup.php
@@ -1,0 +1,157 @@
+
+<?php
+session_start();
+
+require 'connector.php';
+
+$message = '';
+
+// Email validation function
+function validateEmail($email) {
+    return filter_var($email, FILTER_VALIDATE_EMAIL) !== false;
+}
+
+if ($_SERVER["REQUEST_METHOD"] == "POST") {
+    $username = trim($_POST['username']);
+    $email = trim($_POST['email']);
+    $full_name = trim($_POST['full_name']);
+    $password = $_POST['password'];
+    $confirm_password = $_POST['confirm_password'];
+
+    // Server-side validation
+    if (empty($username) || empty($email) || empty($full_name) || empty($password)) {
+        $message = "All fields are required!";
+    } elseif (strlen($username) < 3 || strlen($username) > 100) {
+        $message = "Username must be between 3 and 100 characters!";
+    } elseif (!validateEmail($email)) {
+        $message = "Please enter a valid email address!";
+    } elseif (strlen($email) > 255) {
+        $message = "Email address is too long!";
+    } elseif (strlen($full_name) > 255) {
+        $message = "Full name is too long!";
+    } elseif (strlen($password) < 6) {
+        $message = "Password must be at least 6 characters long!";
+    } elseif ($password !== $confirm_password) {
+        $message = "Passwords do not match!";
+    } else {
+        // Check if username or email already exists
+        $sql = "SELECT user_id FROM users WHERE username = ? OR email = ?";
+        $stmt = $conn->prepare($sql);
+        $stmt->bind_param("ss", $username, $email);
+        $stmt->execute();
+        $result = $stmt->get_result();
+
+        if ($result->num_rows > 0) {
+            $message = "Username or email already exists!";
+        } else {
+            // Insert new user (default to CUSTOMER role)
+            $user_role = 'CUSTOMER';
+            $sql = "INSERT INTO users (username, email, password, full_name, user_role) VALUES (?, ?, ?, ?, ?)";
+            $stmt = $conn->prepare($sql);
+            $stmt->bind_param("sssss", $username, $email, $password, $full_name, $user_role);
+
+            if ($stmt->execute()) {
+                // Log the user in and redirect to home page (app.php)
+                $new_user_id = $conn->insert_id;
+                $_SESSION['user_id'] = $new_user_id;
+                $_SESSION['username'] = $username;
+                $_SESSION['user_role'] = $user_role;
+                $_SESSION['full_name'] = $full_name;
+                $_SESSION['email'] = $email;
+                header("Location: app.php");
+                exit();
+            } else {
+                $message = "Error: Could not create account.";
+            }
+        }
+    }
+}
+?>
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sign Up - Helpdesk</title>
+    <link rel="stylesheet" href="login.css">
+</head>
+<body>
+    <div class="login-container">
+        <h1>Create an Account</h1>
+        <?php if ($message): ?>
+            <p class="message"><?= $message ?></p>
+        <?php endif; ?>
+        <form action="signup.php" method="post">
+            <div class="form-group">
+                <label for="username">Username</label>
+                <input type="text" id="username" name="username" required minlength="3" maxlength="100">
+            </div>
+            <div class="form-group">
+                <label for="email">Email</label>
+                <input type="email" id="email" name="email" required maxlength="255">
+            </div>
+            <div class="form-group">
+                <label for="full_name">Full Name</label>
+                <input type="text" id="full_name" name="full_name" required maxlength="255">
+            </div>
+            <div class="form-group">
+                <label for="password">Password</label>
+                <input type="password" id="password" name="password" required minlength="6">
+            </div>
+            <div class="form-group">
+                <label for="confirm_password">Confirm Password</label>
+                <input type="password" id="confirm_password" name="confirm_password" required minlength="6">
+            </div>
+            <button type="submit">Sign Up</button>
+        </form>
+        <div class="signup-link">
+            <p>Already have an account? <a href="login.php">Login</a></p>
+        </div>
+    </div>
+
+    <script>
+        // Client-side form validation
+        document.addEventListener('DOMContentLoaded', function() {
+            const form = document.querySelector('form');
+            const password = document.getElementById('password');
+            const confirmPassword = document.getElementById('confirm_password');
+            const email = document.getElementById('email');
+            
+            // Real-time password confirmation validation
+            confirmPassword.addEventListener('input', function() {
+                if (password.value !== confirmPassword.value) {
+                    confirmPassword.setCustomValidity('Passwords do not match');
+                } else {
+                    confirmPassword.setCustomValidity('');
+                }
+            });
+            
+            // Email format validation
+            email.addEventListener('input', function() {
+                const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+                if (!emailRegex.test(email.value)) {
+                    email.setCustomValidity('Please enter a valid email address');
+                } else {
+                    email.setCustomValidity('');
+                }
+            });
+            
+            // Form submission validation
+            form.addEventListener('submit', function(e) {
+                if (password.value !== confirmPassword.value) {
+                    e.preventDefault();
+                    alert('Passwords do not match!');
+                    return false;
+                }
+                
+                if (password.value.length < 6) {
+                    e.preventDefault();
+                    alert('Password must be at least 6 characters long!');
+                    return false;
+                }
+            });
+        });
+    </script>
+</body>
+</html>

--- a/Helpdesk/styles.css
+++ b/Helpdesk/styles.css
@@ -1,0 +1,1413 @@
+
+:root {
+    --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    --bg-color: #FFFFFF;
+    --bg-secondary-color: #F7F7F7;
+    --border-color: #E5E5E5;
+    --text-color: #333333;
+    --text-secondary-color: #888888;
+    --accent-color: #2E6DA4;
+}
+
+body {
+    font-family: var(--font-sans);
+    background-color: var(--bg-secondary-color);
+    color: var(--text-color);
+    margin: 0;
+}
+
+.top-nav {
+    background-color: var(--bg-color);
+    border-bottom: 1px solid var(--border-color);
+    padding: 0 40px;
+}
+
+.nav-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    max-width: 1200px;
+    margin: 0 auto;
+    height: 60px;
+}
+
+.nav-brand {
+    font-size: 1.2em;
+    font-weight: 600;
+    color: var(--text-color);
+    text-decoration: none;
+}
+
+.nav-links, .nav-user {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    align-items: center;
+}
+
+.nav-links li a {
+    display: block;
+    padding: 22px 15px;
+    text-decoration: none;
+    color: var(--text-secondary-color);
+    border-bottom: 2px solid transparent;
+}
+
+.nav-links li a:hover {
+    color: var(--text-color);
+}
+
+.nav-links li a.active {
+    color: var(--text-color);
+    border-bottom: 2px solid var(--accent-color);
+}
+
+.nav-user li a {
+    color: var(--text-secondary-color);
+    text-decoration: none;
+    font-size: 0.9em;
+    padding: 10px;
+}
+
+.nav-user li .btn-signup {
+    background-color: var(--accent-color);
+    color: white;
+    border-radius: 5px;
+    padding: 10px 15px;
+}
+
+.nav-user li .btn-signup:hover {
+    background-color: #204d74;
+}
+
+.main-container {
+    padding: 40px;
+}
+
+.container {
+    max-width: 900px;
+    margin: 0 auto;
+    background-color: var(--bg-color);
+    padding: 40px;
+    border-radius: 8px;
+    border: 1px solid var(--border-color);
+}
+
+h1 {
+    font-size: 2em;
+    margin-bottom: 20px;
+}
+
+.page-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 20px;
+}
+
+.btn-create {
+    padding: 10px 15px;
+    background-color: var(--accent-color);
+    color: white;
+    text-decoration: none;
+    border-radius: 5px;
+    font-size: 0.9em;
+}
+
+.btn-create:hover {
+    background-color: #204d74;
+}
+
+/* Filter Bar */
+.filter-bar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 30px;
+    flex-wrap: wrap;
+    gap: 20px;
+}
+
+input[type="text"], input[type="password"] {
+    width: 100%;
+    padding: 10px;
+    border: 1px solid var(--border-color);
+    border-radius: 5px;
+    box-sizing: border-box; /* Important */
+}
+
+.search-form {
+    display: flex;
+}
+
+.search-form input[type="text"] {
+    min-width: 250px;
+    padding: 8px 12px;
+    border: 1px solid var(--border-color);
+    border-radius: 5px 0 0 5px;
+    font-size: 0.9em;
+}
+
+.search-form button {
+    padding: 8px 15px;
+    border: 1px solid var(--accent-color);
+    background-color: var(--accent-color);
+    color: white;
+    border-radius: 0 5px 5px 0;
+    cursor: pointer;
+}
+
+.category-pills {
+    display: flex;
+    gap: 10px;
+}
+
+.category-pills a {
+    display: block;
+    padding: 8px 15px;
+    border-radius: 20px;
+    background-color: var(--bg-secondary-color);
+    color: var(--text-secondary-color);
+    text-decoration: none;
+    font-size: 0.9em;
+    transition: all 0.2s ease;
+}
+
+.category-pills a:hover {
+    background-color: #e0e0e0;
+    color: var(--text-color);
+}
+
+.category-pills a.active {
+    background-color: var(--accent-color);
+    color: white;
+    font-weight: 500;
+}
+
+.posts-list {
+    display: grid;
+    gap: 20px;
+}
+
+.post-card {
+    background-color: var(--bg-color);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 20px;
+    transition: box-shadow 0.2s ease-in-out;
+}
+
+.post-card:hover {
+    box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+}
+
+/* Featured Posts */
+.featured-posts {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 20px;
+    margin-bottom: 30px;
+}
+
+.post-card.featured {
+    background-color: #fdfdfd;
+}
+
+
+.post-card h2 {
+    margin-top: 0;
+    font-size: 1.4em;
+}
+
+.post-card .post-meta {
+    font-size: 0.9em;
+    color: var(--text-secondary-color);
+    margin-bottom: 15px;
+}
+
+.post-card a {
+    color: var(--accent-color);
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.post-content-preview {
+    line-height: 1.6;
+    margin-bottom: 20px;
+}
+
+.card-replies {
+    border-top: 1px solid var(--border-color);
+    margin-top: 20px;
+    padding-top: 15px;
+}
+
+.mini-reply {
+    font-size: 0.9em;
+    background-color: var(--bg-secondary-color);
+    padding: 8px 12px;
+    border-radius: 5px;
+    margin-bottom: 8px;
+}
+
+.mini-reply p {
+    margin: 0;
+}
+
+.reply-form-inline {
+    display: flex;
+    margin-top: 15px;
+}
+
+.reply-form-inline input[type="text"] {
+    flex-grow: 1;
+    border: 1px solid var(--border-color);
+    border-radius: 5px 0 0 5px;
+    padding: 8px 10px;
+    font-size: 0.9em;
+}
+
+.reply-form-inline button {
+    padding: 8px 15px;
+    border: 1px solid var(--accent-color);
+    background-color: var(--accent-color);
+    color: white;
+    border-radius: 0 5px 5px 0;
+    cursor: pointer;
+    font-size: 0.9em;
+}
+
+/* Single Post View */
+.post-content {
+    line-height: 1.6;
+    font-size: 1.1em;
+}
+
+.post-divider {
+    border: 0;
+    border-top: 1px solid var(--border-color);
+    margin: 40px 0;
+}
+
+.replies-list {
+    display: grid;
+    gap: 15px;
+}
+
+.reply-card {
+    background-color: var(--bg-secondary-color);
+    border-radius: 8px;
+    padding: 15px 20px;
+}
+
+.reply-meta {
+    font-size: 0.9em;
+    margin-bottom: 5px;
+}
+
+.reply-meta strong {
+    color: var(--text-color);
+}
+
+.reply-meta .reply-date {
+    color: var(--text-secondary-color);
+}
+
+.reply-card p {
+    margin-top: 0;
+}
+
+/* Reply Form */
+.reply-form {
+    margin-top: 20px;
+    margin-bottom: 30px;
+}
+
+.reply-form textarea {
+    width: 100%;
+    min-height: 80px;
+    padding: 10px;
+    border: 1px solid var(--border-color);
+    border-radius: 5px;
+    box-sizing: border-box;
+    font-family: var(--font-sans);
+    font-size: 1em;
+    margin-bottom: 10px;
+}
+
+.reply-form button {
+    padding: 10px 15px;
+    background-color: var(--accent-color);
+    color: white;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 0.9em;
+}
+
+.reply-form button:hover {
+    background-color: #204d74;
+}
+
+/* Post Form */
+.post-form {
+    margin-top: 20px;
+}
+
+.post-form .form-group {
+    margin-bottom: 20px;
+}
+
+.post-form label {
+    display: block;
+    font-weight: 500;
+    margin-bottom: 8px;
+}
+
+.post-form input[type="text"],
+.post-form textarea {
+    width: 100%;
+    padding: 10px;
+    border: 1px solid var(--border-color);
+    border-radius: 5px;
+    box-sizing: border-box;
+    font-family: var(--font-sans);
+    font-size: 1em;
+}
+
+.post-form button {
+    padding: 10px 20px;
+    background-color: var(--accent-color);
+    color: white;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 1em;
+}
+
+.post-form button:hover {
+    background-color: #204d74;
+}
+
+.post-actions {
+    margin-top: 15px;
+    display: flex;
+    gap: 10px;
+}
+
+.post-action-btn {
+    display: inline-block;
+    padding: 5px 10px;
+    background-color: var(--bg-secondary-color);
+    color: var(--text-color);
+    text-decoration: none;
+    border-radius: 4px;
+    font-size: 0.85em;
+    border: 1px solid var(--border-color);
+}
+
+.post-action-btn:hover {
+    background-color: #e0e0e0;
+}
+
+.post-action-btn.btn-delete {
+    background-color: #f8d7da;
+    color: #721c24;
+    border-color: #f5c6cb;
+}
+
+.post-action-btn.btn-delete:hover {
+    background-color: #f5c6cb;
+}
+
+/* User Table */
+.user-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 20px;
+}
+
+.user-table th, .user-table td {
+    border: 1px solid var(--border-color);
+    padding: 12px 15px;
+    text-align: left;
+}
+
+.user-table thead {
+    background-color: var(--bg-secondary-color);
+}
+
+.user-table th {
+    font-weight: 600;
+}
+
+.user-table tbody tr:nth-of-type(even) {
+    background-color: var(--bg-secondary-color);
+}
+
+.user-table tbody tr:hover {
+    background-color: #e9e9e9;
+}
+
+.btn-action {
+    display: inline-block;
+    padding: 5px 10px;
+    background-color: var(--accent-color);
+    color: white;
+    text-decoration: none;
+    border-radius: 4px;
+    font-size: 0.85em;
+    margin-right: 5px;
+}
+
+.btn-action:hover {
+    background-color: #204d74;
+}
+
+.btn-delete {
+    background-color: #dc3545;
+}
+
+.btn-delete:hover {
+    background-color: #c82333;
+}
+
+/* User Form (for edit) */
+.user-form {
+    margin-top: 20px;
+}
+
+.user-form .form-group {
+    margin-bottom: 20px;
+}
+
+.user-form label {
+    display: block;
+    font-weight: 500;
+    margin-bottom: 8px;
+}
+
+.user-form input[type="text"],
+.user-form select {
+    width: 100%;
+    padding: 10px;
+    border: 1px solid var(--border-color);
+    border-radius: 5px;
+    box-sizing: border-box;
+    font-family: var(--font-sans);
+    font-size: 1em;
+}
+
+.user-form button {
+    padding: 10px 20px;
+    background-color: var(--accent-color);
+    color: white;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 1em;
+}
+
+.user-form button:hover {
+    background-color: #204d74;
+}
+/* User welcome message styling */
+.user-welcome {
+    color: var(--text-secondary-color);
+    font-size: 0.9em;
+    margin-right: 15px;
+    font-weight: 500;
+}
+
+/* Navigation user section spacing */
+.nav-user li {
+    margin-left: 15px;
+}
+
+.nav-user li:first-child {
+    margin-left: 0;
+}
+/* Ticke
+t Form Styles */
+.ticket-form {
+    margin-top: 20px;
+}
+
+.ticket-form .form-group {
+    margin-bottom: 25px;
+}
+
+.ticket-form label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 8px;
+    color: var(--text-color);
+}
+
+.ticket-form .required {
+    color: #dc3545;
+}
+
+.ticket-form input[type="text"],
+.ticket-form select,
+.ticket-form textarea {
+    width: 100%;
+    padding: 12px;
+    border: 1px solid var(--border-color);
+    border-radius: 5px;
+    box-sizing: border-box;
+    font-family: var(--font-sans);
+    font-size: 1em;
+    transition: border-color 0.2s ease;
+}
+
+.ticket-form input[type="text"]:focus,
+.ticket-form select:focus,
+.ticket-form textarea:focus {
+    outline: none;
+    border-color: var(--accent-color);
+    box-shadow: 0 0 0 2px rgba(46, 109, 164, 0.1);
+}
+
+.ticket-form textarea {
+    resize: vertical;
+    min-height: 120px;
+}
+
+.ticket-form input[type="file"] {
+    width: 100%;
+    padding: 8px;
+    border: 1px dashed var(--border-color);
+    border-radius: 5px;
+    background-color: var(--bg-secondary-color);
+    cursor: pointer;
+}
+
+.form-help {
+    font-size: 0.85em;
+    color: var(--text-secondary-color);
+    margin-top: 5px;
+    line-height: 1.4;
+}
+
+.error-message {
+    display: none;
+    color: #dc3545;
+    font-size: 0.85em;
+    margin-top: 5px;
+}
+
+.form-group.has-error input,
+.form-group.has-error select,
+.form-group.has-error textarea {
+    border-color: #dc3545;
+    box-shadow: 0 0 0 2px rgba(220, 53, 69, 0.1);
+}
+
+.form-actions {
+    display: flex;
+    gap: 15px;
+    margin-top: 30px;
+    padding-top: 20px;
+    border-top: 1px solid var(--border-color);
+}
+
+.btn-primary {
+    padding: 12px 24px;
+    background-color: var(--accent-color);
+    color: white;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 1em;
+    font-weight: 500;
+    transition: background-color 0.2s ease;
+}
+
+.btn-primary:hover {
+    background-color: #204d74;
+}
+
+.btn-secondary {
+    padding: 12px 24px;
+    background-color: var(--bg-secondary-color);
+    color: var(--text-color);
+    border: 1px solid var(--border-color);
+    border-radius: 5px;
+    text-decoration: none;
+    font-size: 1em;
+    font-weight: 500;
+    transition: all 0.2s ease;
+    display: inline-block;
+    text-align: center;
+}
+
+.btn-secondary:hover {
+    background-color: #e0e0e0;
+    border-color: #ccc;
+}
+
+/* File Preview Styles */
+.file-preview-container {
+    margin-top: 15px;
+    padding: 15px;
+    background-color: var(--bg-secondary-color);
+    border-radius: 5px;
+    border: 1px solid var(--border-color);
+}
+
+.file-preview-container h4 {
+    margin: 0 0 10px 0;
+    font-size: 0.9em;
+    color: var(--text-color);
+}
+
+.file-preview-item {
+    display: flex;
+    align-items: center;
+    padding: 5px 0;
+    border-bottom: 1px solid #ddd;
+}
+
+.file-preview-item:last-child {
+    border-bottom: none;
+}
+
+.file-preview-item span {
+    font-size: 0.85em;
+}
+
+.file-size {
+    color: var(--text-secondary-color);
+    margin-left: auto;
+}
+
+/* Alert Styles */
+.alert {
+    padding: 15px;
+    margin-bottom: 20px;
+    border-radius: 5px;
+    font-size: 0.95em;
+}
+
+.alert-success {
+    background-color: #d4edda;
+    color: #155724;
+    border: 1px solid #c3e6cb;
+}
+
+.alert-error {
+    background-color: #f8d7da;
+    color: #721c24;
+    border: 1px solid #f5c6cb;
+}
+
+/* Priority and Category Styling */
+.priority-low { color: #28a745; }
+.priority-medium { color: #ffc107; }
+.priority-high { color: #fd7e14; }
+.priority-urgent { color: #dc3545; }
+
+.category-technical { color: #dc3545; }
+.category-billing { color: #ffc107; }
+.category-general { color: #28a745; }
+
+/* Responsive Design */
+@media (max-width: 768px) {
+    .form-actions {
+        flex-direction: column;
+    }
+    
+    .btn-primary,
+    .btn-secondary {
+        width: 100%;
+        text-align: center;
+    }
+    
+    .ticket-form input[type="text"],
+    .ticket-form select,
+    .ticket-form textarea {
+        font-size: 16px; /* Prevents zoom on iOS */
+    }
+}/* Ti
+cket Dashboard Styles */
+.filter-pills-container {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.filter-label {
+    font-weight: 600;
+    color: var(--text-color);
+    margin-right: 10px;
+    font-size: 0.9em;
+}
+
+.results-summary {
+    margin-bottom: 20px;
+    padding: 10px 0;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.results-summary p {
+    margin: 0;
+    color: var(--text-secondary-color);
+    font-size: 0.9em;
+}
+
+/* Ticket List Styles */
+.tickets-list {
+    display: grid;
+    gap: 20px;
+    margin-bottom: 30px;
+}
+
+.ticket-card {
+    background-color: var(--bg-color);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 20px;
+    transition: box-shadow 0.2s ease-in-out;
+}
+
+.ticket-card:hover {
+    box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+}
+
+.ticket-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 15px;
+}
+
+.ticket-header h3 {
+    margin: 0;
+    font-size: 1.2em;
+    line-height: 1.3;
+}
+
+.ticket-header h3 a {
+    color: var(--text-color);
+    text-decoration: none;
+}
+
+.ticket-header h3 a:hover {
+    color: var(--accent-color);
+}
+
+.ticket-badges {
+    display: flex;
+    gap: 8px;
+    flex-shrink: 0;
+    margin-left: 15px;
+}
+
+.badge {
+    padding: 4px 8px;
+    border-radius: 12px;
+    font-size: 0.75em;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+/* Priority badges */
+.badge.priority-low {
+    background-color: #d4edda;
+    color: #155724;
+}
+
+.badge.priority-medium {
+    background-color: #fff3cd;
+    color: #856404;
+}
+
+.badge.priority-high {
+    background-color: #f8d7da;
+    color: #721c24;
+}
+
+.badge.priority-urgent {
+    background-color: #dc3545;
+    color: white;
+}
+
+/* Status badges */
+.badge.status-open {
+    background-color: #cce5ff;
+    color: #004085;
+}
+
+.badge.status-in-progress {
+    background-color: #fff3cd;
+    color: #856404;
+}
+
+.badge.status-resolved {
+    background-color: #d4edda;
+    color: #155724;
+}
+
+.badge.status-closed {
+    background-color: #e2e3e5;
+    color: #383d41;
+}
+
+.ticket-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 15px;
+    margin-bottom: 15px;
+    font-size: 0.85em;
+    color: var(--text-secondary-color);
+}
+
+.ticket-meta span {
+    display: flex;
+    align-items: center;
+}
+
+.ticket-meta .category {
+    font-weight: 600;
+    padding: 2px 6px;
+    border-radius: 4px;
+    background-color: var(--bg-secondary-color);
+}
+
+.ticket-description {
+    margin-bottom: 15px;
+    line-height: 1.5;
+}
+
+.ticket-description p {
+    margin: 0;
+    color: var(--text-color);
+}
+
+.ticket-footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding-top: 15px;
+    border-top: 1px solid var(--border-color);
+}
+
+.reply-count {
+    font-size: 0.85em;
+    color: var(--text-secondary-color);
+}
+
+.btn-view-ticket {
+    padding: 6px 12px;
+    background-color: var(--accent-color);
+    color: white;
+    text-decoration: none;
+    border-radius: 4px;
+    font-size: 0.85em;
+    font-weight: 500;
+    transition: background-color 0.2s ease;
+}
+
+.btn-view-ticket:hover {
+    background-color: #204d74;
+}
+
+/* No tickets state */
+.no-tickets {
+    text-align: center;
+    padding: 40px 20px;
+    color: var(--text-secondary-color);
+}
+
+.no-tickets p {
+    margin-bottom: 15px;
+    font-size: 1.1em;
+}
+
+.no-tickets a {
+    color: var(--accent-color);
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.no-tickets a:hover {
+    text-decoration: underline;
+}
+
+/* Pagination Styles */
+.pagination {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 5px;
+    margin-top: 30px;
+    padding: 20px 0;
+}
+
+.pagination-link {
+    display: inline-block;
+    padding: 8px 12px;
+    border: 1px solid var(--border-color);
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    text-decoration: none;
+    border-radius: 4px;
+    font-size: 0.9em;
+    transition: all 0.2s ease;
+}
+
+.pagination-link:hover {
+    background-color: var(--bg-secondary-color);
+    border-color: var(--accent-color);
+}
+
+.pagination-link.active {
+    background-color: var(--accent-color);
+    color: white;
+    border-color: var(--accent-color);
+}
+
+.pagination-ellipsis {
+    padding: 8px 4px;
+    color: var(--text-secondary-color);
+    font-size: 0.9em;
+}
+
+/* Responsive Design for Ticket Dashboard */
+@media (max-width: 768px) {
+    .filter-bar {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    
+    .search-form {
+        margin-bottom: 15px;
+    }
+    
+    .search-form input[type="text"] {
+        min-width: auto;
+    }
+    
+    .filter-pills-container {
+        gap: 15px;
+    }
+    
+    .category-pills {
+        flex-wrap: wrap;
+    }
+    
+    .ticket-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 10px;
+    }
+    
+    .ticket-badges {
+        margin-left: 0;
+    }
+    
+    .ticket-meta {
+        flex-direction: column;
+        gap: 8px;
+    }
+    
+    .ticket-footer {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 10px;
+    }
+    
+    .pagination {
+        flex-wrap: wrap;
+        gap: 3px;
+    }
+    
+    .pagination-link {
+        padding: 6px 10px;
+        font-size: 0.85em;
+    }
+}
+
+@media (max-width: 480px) {
+    .ticket-card {
+        padding: 15px;
+    }
+    
+    .ticket-header h3 {
+        font-size: 1.1em;
+    }
+    
+    .category-pills a {
+        padding: 6px 10px;
+        font-size: 0.8em;
+    }
+}
+/*
+ Ticket Detail View Styles */
+.ticket-detail-container {
+    max-width: 900px;
+    margin: 0 auto;
+}
+
+.ticket-detail-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 30px;
+    padding-bottom: 20px;
+    border-bottom: 2px solid var(--border-color);
+}
+
+.ticket-title-section h1 {
+    margin: 0 0 10px 0;
+    font-size: 1.8em;
+    color: var(--text-color);
+}
+
+.ticket-detail-header .ticket-badges {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.btn-back {
+    display: inline-block;
+    padding: 10px 15px;
+    background-color: var(--bg-secondary-color);
+    color: var(--text-color);
+    text-decoration: none;
+    border-radius: 5px;
+    border: 1px solid var(--border-color);
+    font-size: 0.9em;
+}
+
+.btn-back:hover {
+    background-color: #e0e0e0;
+}
+
+.ticket-meta-section {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 15px;
+    margin-bottom: 30px;
+    padding: 20px;
+    background-color: var(--bg-secondary-color);
+    border-radius: 8px;
+}
+
+.meta-item {
+    font-size: 0.95em;
+}
+
+.meta-item strong {
+    color: var(--text-color);
+    margin-right: 8px;
+}
+
+.ticket-content-section {
+    margin-bottom: 40px;
+}
+
+.ticket-content-section h3 {
+    margin-bottom: 15px;
+    color: var(--text-color);
+    border-bottom: 1px solid var(--border-color);
+    padding-bottom: 8px;
+}
+
+.ticket-content {
+    background-color: var(--bg-secondary-color);
+    padding: 20px;
+    border-radius: 8px;
+    line-height: 1.6;
+    margin-bottom: 20px;
+}
+
+.attachments-section {
+    margin-top: 20px;
+}
+
+.attachments-section h4 {
+    margin-bottom: 10px;
+    color: var(--text-color);
+}
+
+.attachments-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.attachment-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 12px;
+    background-color: var(--bg-color);
+    border: 1px solid var(--border-color);
+    border-radius: 5px;
+}
+
+.attachment-link {
+    color: var(--accent-color);
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.attachment-link:hover {
+    text-decoration: underline;
+}
+
+.attachment-size {
+    color: var(--text-secondary-color);
+    font-size: 0.85em;
+}
+
+.replies-section {
+    margin-bottom: 40px;
+}
+
+.replies-section h3 {
+    margin-bottom: 20px;
+    color: var(--text-color);
+    border-bottom: 1px solid var(--border-color);
+    padding-bottom: 8px;
+}
+
+.replies-list {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.reply-item {
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    overflow: hidden;
+}
+
+.reply-item.internal-note {
+    border-color: #f0ad4e;
+    background-color: #fef9e7;
+}
+
+.reply-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 15px 20px;
+    background-color: var(--bg-secondary-color);
+    border-bottom: 1px solid var(--border-color);
+}
+
+.reply-item.internal-note .reply-header {
+    background-color: #fcf4d6;
+}
+
+.reply-author {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.role-badge {
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 0.75em;
+    font-weight: 500;
+}
+
+.role-badge.admin {
+    background-color: var(--accent-color);
+    color: white;
+}
+
+.role-badge.customer {
+    background-color: #5cb85c;
+    color: white;
+}
+
+.internal-badge {
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 0.75em;
+    font-weight: 500;
+    background-color: #f0ad4e;
+    color: white;
+}
+
+.reply-date {
+    color: var(--text-secondary-color);
+    font-size: 0.9em;
+}
+
+.reply-content {
+    padding: 20px;
+    line-height: 1.6;
+}
+
+.reply-attachments {
+    padding: 0 20px 20px 20px;
+    border-top: 1px solid var(--border-color);
+}
+
+.reply-form-section {
+    margin-bottom: 30px;
+}
+
+.reply-form-section h3 {
+    margin-bottom: 20px;
+    color: var(--text-color);
+    border-bottom: 1px solid var(--border-color);
+    padding-bottom: 8px;
+}
+
+.reply-form {
+    background-color: var(--bg-secondary-color);
+    padding: 25px;
+    border-radius: 8px;
+    border: 1px solid var(--border-color);
+}
+
+.reply-form .form-group {
+    margin-bottom: 20px;
+}
+
+.reply-form label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 8px;
+    color: var(--text-color);
+}
+
+.reply-form textarea {
+    width: 100%;
+    min-height: 120px;
+    padding: 12px;
+    border: 1px solid var(--border-color);
+    border-radius: 5px;
+    font-family: var(--font-sans);
+    font-size: 1em;
+    resize: vertical;
+    box-sizing: border-box;
+}
+
+.reply-form textarea:focus {
+    outline: none;
+    border-color: var(--accent-color);
+    box-shadow: 0 0 0 2px rgba(46, 109, 164, 0.1);
+}
+
+.reply-form input[type="checkbox"] {
+    margin-right: 8px;
+}
+
+.reply-form input[type="file"] {
+    width: 100%;
+    padding: 8px;
+    border: 1px solid var(--border-color);
+    border-radius: 5px;
+    background-color: var(--bg-color);
+}
+
+.file-help {
+    display: block;
+    margin-top: 5px;
+    color: var(--text-secondary-color);
+    font-size: 0.85em;
+}
+
+.form-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+}
+
+.btn-submit {
+    padding: 12px 25px;
+    background-color: var(--accent-color);
+    color: white;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 1em;
+    font-weight: 500;
+}
+
+.btn-submit:hover {
+    background-color: #204d74;
+}
+
+.ticket-closed-notice {
+    background-color: #f8d7da;
+    color: #721c24;
+    padding: 20px;
+    border-radius: 8px;
+    border: 1px solid #f5c6cb;
+    text-align: center;
+}
+
+.error-message {
+    background-color: #f8d7da;
+    color: #721c24;
+    padding: 15px;
+    border-radius: 5px;
+    border: 1px solid #f5c6cb;
+    margin-bottom: 20px;
+}
+
+/* Success/Error Messages */
+.success-message {
+    background-color: #d4edda;
+    color: #155724;
+    padding: 15px;
+    border-radius: 5px;
+    border: 1px solid #c3e6cb;
+    margin-bottom: 20px;
+}
+
+/* Mobile Responsiveness for Ticket Detail */
+@media (max-width: 768px) {
+    .ticket-detail-header {
+        flex-direction: column;
+        gap: 15px;
+    }
+    
+    .ticket-meta-section {
+        grid-template-columns: 1fr;
+        gap: 10px;
+    }
+    
+    .reply-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 8px;
+    }
+    
+    .reply-author {
+        flex-wrap: wrap;
+    }
+    
+    .attachment-item {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 5px;
+    }
+}
+
+@media (max-width: 480px) {
+    .ticket-detail-container {
+        padding: 0 10px;
+    }
+    
+    .reply-form {
+        padding: 15px;
+    }
+    
+    .ticket-content {
+        padding: 15px;
+    }
+}

--- a/Helpdesk/test_auth.php
+++ b/Helpdesk/test_auth.php
@@ -1,0 +1,70 @@
+<?php
+// Simple test script to verify database connection and user table structure
+require 'connector.php';
+
+echo "<h2>Testing Enhanced Authentication System</h2>";
+
+// Test database connection
+if ($conn->connect_error) {
+    echo "<p style='color: red;'>❌ Database connection failed: " . $conn->connect_error . "</p>";
+    exit();
+} else {
+    echo "<p style='color: green;'>✅ Database connection successful</p>";
+}
+
+// Test users table structure
+$sql = "DESCRIBE users";
+$result = $conn->query($sql);
+
+if ($result) {
+    echo "<h3>Users Table Structure:</h3>";
+    echo "<table border='1' style='border-collapse: collapse;'>";
+    echo "<tr><th>Field</th><th>Type</th><th>Null</th><th>Key</th><th>Default</th><th>Extra</th></tr>";
+    
+    while ($row = $result->fetch_assoc()) {
+        echo "<tr>";
+        echo "<td>" . $row['Field'] . "</td>";
+        echo "<td>" . $row['Type'] . "</td>";
+        echo "<td>" . $row['Null'] . "</td>";
+        echo "<td>" . $row['Key'] . "</td>";
+        echo "<td>" . $row['Default'] . "</td>";
+        echo "<td>" . $row['Extra'] . "</td>";
+        echo "</tr>";
+    }
+    echo "</table>";
+    echo "<p style='color: green;'>✅ Users table structure is correct</p>";
+} else {
+    echo "<p style='color: red;'>❌ Could not describe users table: " . $conn->error . "</p>";
+}
+
+// Test sample data
+$sql = "SELECT user_id, username, email, full_name, user_role FROM users LIMIT 5";
+$result = $conn->query($sql);
+
+if ($result && $result->num_rows > 0) {
+    echo "<h3>Sample Users:</h3>";
+    echo "<table border='1' style='border-collapse: collapse;'>";
+    echo "<tr><th>ID</th><th>Username</th><th>Email</th><th>Full Name</th><th>Role</th></tr>";
+    
+    while ($row = $result->fetch_assoc()) {
+        echo "<tr>";
+        echo "<td>" . $row['user_id'] . "</td>";
+        echo "<td>" . $row['username'] . "</td>";
+        echo "<td>" . $row['email'] . "</td>";
+        echo "<td>" . $row['full_name'] . "</td>";
+        echo "<td>" . $row['user_role'] . "</td>";
+        echo "</tr>";
+    }
+    echo "</table>";
+    echo "<p style='color: green;'>✅ Sample users found in database</p>";
+} else {
+    echo "<p style='color: orange;'>⚠️ No users found in database</p>";
+}
+
+echo "<h3>Test Links:</h3>";
+echo "<p><a href='signup.php'>Test Signup Form</a></p>";
+echo "<p><a href='login.php'>Test Login Form</a></p>";
+echo "<p><a href='app.php'>Test Main Application</a></p>";
+
+$conn->close();
+?>

--- a/Helpdesk/views/create_post.php
+++ b/Helpdesk/views/create_post.php
@@ -1,0 +1,46 @@
+<?php
+// This file is views/create_post.php
+
+if (!isset($_SESSION['user_id']) || !in_array($_SESSION['user_type'], ['ADMIN', 'MEMBER'])) {
+    echo '<h1>Access Denied</h1>';
+    exit(); // Use exit() instead of break for included files
+}
+?>
+<h1>Create a New Post</h1>
+<form action="actions/create_post.php" method="POST" class="post-form">
+    <div class="form-group">
+        <label for="title">Title</label>
+        <input type="text" id="title" name="title" required>
+    </div>
+    <div class="form-group">
+        <label for="category">Category</label>
+        <select id="category" name="category" required>
+            <option value="">Select a category</option>
+            <?php foreach ($all_categories as $cat): ?>
+                <option value="<?= htmlspecialchars($cat) ?>"><?= htmlspecialchars($cat) ?></option>
+            <?php endforeach; ?>
+            <option value="Other">Other (specify below)</option>
+        </select>
+    </div>
+    <div class="form-group" id="new-category-group" style="display:none;">
+        <label for="new_category">New Category</label>
+        <input type="text" id="new_category" name="new_category">
+    </div>
+    <div class="form-group">
+        <label for="content">Content</label>
+        <textarea id="content" name="content" rows="10" required></textarea>
+    </div>
+    <button type="submit">Create Post</button>
+</form>
+<script>
+    document.getElementById('category').addEventListener('change', function() {
+        var newCategoryGroup = document.getElementById('new-category-group');
+        if (this.value === 'Other') {
+            newCategoryGroup.style.display = 'block';
+            document.getElementById('new_category').setAttribute('required', 'required');
+        } else {
+            newCategoryGroup.style.display = 'none';
+            document.getElementById('new_category').removeAttribute('required');
+        }
+    });
+</script>

--- a/Helpdesk/views/create_ticket.php
+++ b/Helpdesk/views/create_ticket.php
@@ -1,0 +1,297 @@
+<?php
+// Ensure user is logged in and is a customer
+if (!isset($_SESSION['user_id']) || $_SESSION['user_role'] !== 'CUSTOMER') {
+    header("Location: login.php");
+    exit();
+}
+
+// Handle form submission messages
+$success_message = '';
+$error_message = '';
+if (isset($_GET['success']) && $_GET['success'] == '1') {
+    $success_message = 'Ticket created successfully! You can view it in your ticket history.';
+}
+if (isset($_GET['error'])) {
+    switch ($_GET['error']) {
+        case 'validation':
+            $error_message = 'Please fill in all required fields correctly.';
+            break;
+        case 'upload':
+            $error_message = 'File upload failed. Please check file size and type.';
+            break;
+        case 'database':
+            $error_message = 'Database error occurred. Please try again.';
+            break;
+        default:
+            $error_message = 'An error occurred. Please try again.';
+    }
+}
+?>
+
+<div class="page-header">
+    <h1>Create New Support Ticket</h1>
+</div>
+
+<?php if ($success_message): ?>
+    <div class="alert alert-success">
+        <?= htmlspecialchars($success_message) ?>
+    </div>
+<?php endif; ?>
+
+<?php if ($error_message): ?>
+    <div class="alert alert-error">
+        <?= htmlspecialchars($error_message) ?>
+    </div>
+<?php endif; ?>
+
+<form id="ticketForm" class="ticket-form" action="actions/create_ticket.php" method="POST" enctype="multipart/form-data">
+    <div class="form-group">
+        <label for="title">Ticket Title <span class="required">*</span></label>
+        <input type="text" id="title" name="title" required maxlength="255" 
+               placeholder="Brief description of your issue">
+        <div class="error-message" id="title-error"></div>
+    </div>
+
+    <div class="form-group">
+        <label for="category">Category <span class="required">*</span></label>
+        <select id="category" name="category" required>
+            <option value="">Select a category</option>
+            <option value="Technical">Technical Support</option>
+            <option value="Billing">Billing & Payment</option>
+            <option value="General">General Inquiry</option>
+        </select>
+        <div class="error-message" id="category-error"></div>
+    </div>
+
+    <div class="form-group">
+        <label for="priority">Priority <span class="required">*</span></label>
+        <select id="priority" name="priority" required>
+            <option value="">Select priority level</option>
+            <option value="Low">Low - General question or minor issue</option>
+            <option value="Medium" selected>Medium - Standard support request</option>
+            <option value="High">High - Important issue affecting work</option>
+            <option value="Urgent">Urgent - Critical issue requiring immediate attention</option>
+        </select>
+        <div class="error-message" id="priority-error"></div>
+    </div>
+
+    <div class="form-group">
+        <label for="description">Description <span class="required">*</span></label>
+        <textarea id="description" name="description" required rows="6" 
+                  placeholder="Please provide detailed information about your issue, including any error messages, steps to reproduce, and what you expected to happen."></textarea>
+        <div class="error-message" id="description-error"></div>
+        <div class="form-help">Minimum 10 characters required</div>
+    </div>
+
+    <div class="form-group">
+        <label for="attachments">File Attachments (Optional)</label>
+        <input type="file" id="attachments" name="attachments[]" multiple 
+               accept=".jpg,.jpeg,.png,.gif,.pdf,.doc,.docx,.txt">
+        <div class="form-help">
+            Supported formats: JPG, PNG, GIF, PDF, DOC, DOCX, TXT<br>
+            Maximum file size: 5MB per file<br>
+            Maximum 5 files per ticket
+        </div>
+        <div class="error-message" id="attachments-error"></div>
+        <div id="file-preview"></div>
+    </div>
+
+    <div class="form-actions">
+        <button type="submit" class="btn-primary">Create Ticket</button>
+        <a href="app.php?view=my_tickets" class="btn-secondary">Cancel</a>
+    </div>
+</form>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const form = document.getElementById('ticketForm');
+    const titleInput = document.getElementById('title');
+    const categorySelect = document.getElementById('category');
+    const prioritySelect = document.getElementById('priority');
+    const descriptionTextarea = document.getElementById('description');
+    const attachmentsInput = document.getElementById('attachments');
+    const filePreview = document.getElementById('file-preview');
+
+    // Real-time validation
+    titleInput.addEventListener('blur', validateTitle);
+    categorySelect.addEventListener('change', validateCategory);
+    prioritySelect.addEventListener('change', validatePriority);
+    descriptionTextarea.addEventListener('blur', validateDescription);
+    attachmentsInput.addEventListener('change', validateAttachments);
+
+    // Form submission validation
+    form.addEventListener('submit', function(e) {
+        let isValid = true;
+        
+        if (!validateTitle()) isValid = false;
+        if (!validateCategory()) isValid = false;
+        if (!validatePriority()) isValid = false;
+        if (!validateDescription()) isValid = false;
+        if (!validateAttachments()) isValid = false;
+
+        if (!isValid) {
+            e.preventDefault();
+            showError('Please correct the errors above before submitting.');
+        }
+    });
+
+    function validateTitle() {
+        const value = titleInput.value.trim();
+        const errorElement = document.getElementById('title-error');
+        
+        if (value.length === 0) {
+            showFieldError(errorElement, 'Title is required');
+            return false;
+        } else if (value.length < 5) {
+            showFieldError(errorElement, 'Title must be at least 5 characters long');
+            return false;
+        } else if (value.length > 255) {
+            showFieldError(errorElement, 'Title must be less than 255 characters');
+            return false;
+        }
+        
+        hideFieldError(errorElement);
+        return true;
+    }
+
+    function validateCategory() {
+        const value = categorySelect.value;
+        const errorElement = document.getElementById('category-error');
+        
+        if (!value) {
+            showFieldError(errorElement, 'Please select a category');
+            return false;
+        }
+        
+        hideFieldError(errorElement);
+        return true;
+    }
+
+    function validatePriority() {
+        const value = prioritySelect.value;
+        const errorElement = document.getElementById('priority-error');
+        
+        if (!value) {
+            showFieldError(errorElement, 'Please select a priority level');
+            return false;
+        }
+        
+        hideFieldError(errorElement);
+        return true;
+    }
+
+    function validateDescription() {
+        const value = descriptionTextarea.value.trim();
+        const errorElement = document.getElementById('description-error');
+        
+        if (value.length === 0) {
+            showFieldError(errorElement, 'Description is required');
+            return false;
+        } else if (value.length < 10) {
+            showFieldError(errorElement, 'Description must be at least 10 characters long');
+            return false;
+        }
+        
+        hideFieldError(errorElement);
+        return true;
+    }
+
+    function validateAttachments() {
+        const files = attachmentsInput.files;
+        const errorElement = document.getElementById('attachments-error');
+        const maxFileSize = 5 * 1024 * 1024; // 5MB
+        const maxFiles = 5;
+        const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 
+                             'application/pdf', 'application/msword', 
+                             'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+                             'text/plain'];
+
+        if (files.length > maxFiles) {
+            showFieldError(errorElement, `Maximum ${maxFiles} files allowed`);
+            return false;
+        }
+
+        for (let i = 0; i < files.length; i++) {
+            const file = files[i];
+            
+            if (file.size > maxFileSize) {
+                showFieldError(errorElement, `File "${file.name}" is too large. Maximum size is 5MB`);
+                return false;
+            }
+            
+            if (!allowedTypes.includes(file.type)) {
+                showFieldError(errorElement, `File "${file.name}" has an unsupported format`);
+                return false;
+            }
+        }
+
+        hideFieldError(errorElement);
+        updateFilePreview(files);
+        return true;
+    }
+
+    function updateFilePreview(files) {
+        filePreview.innerHTML = '';
+        
+        if (files.length === 0) return;
+
+        const previewContainer = document.createElement('div');
+        previewContainer.className = 'file-preview-container';
+        
+        const title = document.createElement('h4');
+        title.textContent = 'Selected Files:';
+        previewContainer.appendChild(title);
+
+        for (let i = 0; i < files.length; i++) {
+            const file = files[i];
+            const fileItem = document.createElement('div');
+            fileItem.className = 'file-preview-item';
+            
+            const fileName = document.createElement('span');
+            fileName.textContent = file.name;
+            
+            const fileSize = document.createElement('span');
+            fileSize.className = 'file-size';
+            fileSize.textContent = ` (${formatFileSize(file.size)})`;
+            
+            fileItem.appendChild(fileName);
+            fileItem.appendChild(fileSize);
+            previewContainer.appendChild(fileItem);
+        }
+        
+        filePreview.appendChild(previewContainer);
+    }
+
+    function formatFileSize(bytes) {
+        if (bytes === 0) return '0 Bytes';
+        const k = 1024;
+        const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+        const i = Math.floor(Math.log(bytes) / Math.log(k));
+        return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+    }
+
+    function showFieldError(element, message) {
+        element.textContent = message;
+        element.style.display = 'block';
+        element.parentElement.classList.add('has-error');
+    }
+
+    function hideFieldError(element) {
+        element.textContent = '';
+        element.style.display = 'none';
+        element.parentElement.classList.remove('has-error');
+    }
+
+    function showError(message) {
+        // Create or update error alert
+        let alertElement = document.querySelector('.alert-error');
+        if (!alertElement) {
+            alertElement = document.createElement('div');
+            alertElement.className = 'alert alert-error';
+            form.parentNode.insertBefore(alertElement, form);
+        }
+        alertElement.textContent = message;
+        alertElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+});
+</script>

--- a/Helpdesk/views/edit_post.php
+++ b/Helpdesk/views/edit_post.php
@@ -1,0 +1,72 @@
+<?php
+// This file is views/edit_post.php
+
+if (!isset($_SESSION['user_id'])) {
+    echo '<h1>Access Denied</h1>';
+    exit(); // Use exit() instead of break for included files
+}
+require 'connector.php';
+$post_id = $_GET['id'] ?? 0;
+$post_data = null;
+
+if ($post_id > 0) {
+    $sql = "SELECT title, content, category, author_id FROM posts WHERE post_id = ?";
+    $stmt = $conn->prepare($sql);
+    $stmt->bind_param("i", $post_id);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    if ($result->num_rows == 1) {
+        $post_data = $result->fetch_assoc();
+        // Check if user is author or admin
+        if ($post_data['author_id'] != $_SESSION['user_id'] && $_SESSION['user_type'] !== 'ADMIN') {
+            echo '<h1>Access Denied</h1>';
+            exit(); // Use exit() instead of break for included files
+        }
+    }
+}
+
+if ($post_data) {
+    ?>
+    <h1>Edit Post: <?= htmlspecialchars($post_data['title']) ?></h1>
+    <form action="actions/update_post.php" method="POST" class="post-form">
+        <input type="hidden" name="post_id" value="<?= $post_id ">
+        <div class="form-group">
+            <label for="title">Title</label>
+            <input type="text" id="title" name="title" value="<?= htmlspecialchars($post_data['title']) ?>" required>
+        </div>
+        <div class="form-group">
+            <label for="content">Content</label>
+            <textarea id="content" name="content" rows="10" required><?= htmlspecialchars($post_data['content']) ?></textarea>
+        </div>
+        <div class="form-group">
+            <label for="category">Category</label>
+            <select id="category" name="category" required>
+                <option value="">Select a category</option>
+                <?php foreach ($all_categories as $cat): ?>
+                    <option value="<?= htmlspecialchars($cat) ?>" <?= ($post_data['category'] === $cat ? 'selected' : '') ?>><?= htmlspecialchars($cat) ?></option>
+                <?php endforeach; ?>
+                <option value="Other" <?= (!in_array($post_data['category'], $all_categories) ? 'selected' : '') ?>>Other (specify below)</option>
+            </select>
+        </div>
+        <div class="form-group" id="new-category-group" style="display:<?= (!in_array($post_data['category'], $all_categories) ? 'block' : 'none') ?>;">
+            <label for="new_category">New Category</label>
+            <input type="text" id="new_category" name="new_category" value="<?= (!in_array($post_data['category'], $all_categories) ? htmlspecialchars($post_data['category']) : '') ?>">
+        </div>
+        <button type="submit">Update Post</button>
+    </form>
+    <script>
+        document.getElementById('category').addEventListener('change', function() {
+            var newCategoryGroup = document.getElementById('new-category-group');
+            if (this.value === 'Other') {
+                newCategoryGroup.style.display = 'block';
+                document.getElementById('new_category').setAttribute('required', 'required');
+            } else {
+                newCategoryGroup.style.display = 'none';
+                document.getElementById('new_category').removeAttribute('required');
+            }
+        });
+    </script>
+    <?php
+} else {
+    echo '<h1>Post not found.</h1>';
+}

--- a/Helpdesk/views/edit_profile.php
+++ b/Helpdesk/views/edit_profile.php
@@ -1,0 +1,43 @@
+<?php
+// This file is views/edit_profile.php
+
+if (!isset($_SESSION['user_id'])) {
+    echo '<h1>Access Denied</h1>';
+    exit();
+}
+
+require 'connector.php';
+
+$user_id = $_SESSION['user_id'];
+$user_data = null;
+
+if ($user_id > 0) {
+    $sql = "SELECT user_id, user_name FROM user WHERE user_id = ?";
+    $stmt = $conn->prepare($sql);
+    $stmt->bind_param("i", $user_id);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    if ($result->num_rows == 1) {
+        $user_data = $result->fetch_assoc();
+    }
+}
+
+if ($user_data) {
+    ?>
+    <h1>Edit Your Profile</h1>
+    <form action="actions/update_profile.php" method="POST" class="user-form">
+        <input type="hidden" name="user_id" value="<?= htmlspecialchars($user_data['user_id']) ?>">
+        <div class="form-group">
+            <label for="username">Username</label>
+            <input type="text" id="username" name="user_name" value="<?= htmlspecialchars($user_data['user_name']) ?>" required>
+        </div>
+        <div class="form-group">
+            <label for="password">New Password (leave blank to keep current)</label>
+            <input type="password" id="password" name="password">
+        </div>
+        <button type="submit">Update Profile</button>
+    </form>
+    <?php
+} else {
+    echo '<h1>User not found.</h1>';
+}

--- a/Helpdesk/views/edit_user.php
+++ b/Helpdesk/views/edit_user.php
@@ -1,0 +1,44 @@
+<?php
+// This file is views/edit_user.php
+
+if (!isset($_SESSION['user_type']) || $_SESSION['user_type'] !== 'ADMIN') {
+    echo '<h1>Access Denied</h1>';
+    exit(); // Use exit() instead of break for included files
+}
+require 'connector.php';
+$user_id = $_GET['id'] ?? 0;
+$user_data = null;
+
+if ($user_id > 0) {
+    $sql = "SELECT user_id, user_name, user_type FROM user WHERE user_id = ?";
+    $stmt = $conn->prepare($sql);
+    $stmt->bind_param("i", $user_id);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    if ($result->num_rows == 1) {
+        $user_data = $result->fetch_assoc();
+    }
+}
+
+if ($user_data) {
+    ?>
+    <h1>Edit User</h1>
+    <form action="actions/update_user.php" method="POST" class="user-form">
+        <input type="hidden" name="user_id" value="<?= htmlspecialchars($user_data['user_id']) ?>">
+        <div class="form-group">
+            <label for="username">Username</label>
+            <input type="text" id="username" name="user_name" value="<?= htmlspecialchars($user_data['user_name']) ?>" required>
+        </div>
+        <div class="form-group">
+            <label for="user_type">User Type</label>
+            <select id="user_type" name="user_type">
+                <option value="ADMIN" <?= ($user_data['user_type'] === 'ADMIN' ? 'selected' : '') ?>>ADMIN</option>
+                <option value="MEMBER" <?= ($user_data['user_type'] === 'MEMBER' ? 'selected' : '') ?>>MEMBER</option>
+            </select>
+        </div>
+        <button type="submit">Update User</button>
+    </form>
+    <?php
+} else {
+    echo '<h1>User not found.</h1>';
+}

--- a/Helpdesk/views/my_tickets.php
+++ b/Helpdesk/views/my_tickets.php
@@ -1,0 +1,246 @@
+<?php
+// This file is views/my_tickets.php - Customer ticket dashboard
+
+// Ensure user is a customer
+if ($_SESSION['user_role'] !== 'CUSTOMER') {
+    header("Location: app.php?view=dashboard");
+    exit();
+}
+
+require 'connector.php';
+
+// Get filter parameters
+$status_filter = $_GET['status'] ?? 'All';
+$category_filter = $_GET['category'] ?? 'All';
+$search_term = $_GET['search'] ?? '';
+$page = max(1, intval($_GET['page'] ?? 1));
+$per_page = 10;
+$offset = ($page - 1) * $per_page;
+
+// Build the WHERE clause for filtering
+$where_clauses = ["t.customer_id = ?"];
+$params = [$_SESSION['user_id']];
+$types = 'i';
+
+if ($status_filter !== 'All') {
+    $where_clauses[] = "t.status = ?";
+    $params[] = $status_filter;
+    $types .= 's';
+}
+
+if ($category_filter !== 'All') {
+    $where_clauses[] = "t.category = ?";
+    $params[] = $category_filter;
+    $types .= 's';
+}
+
+if (!empty($search_term)) {
+    $where_clauses[] = "(t.title LIKE ? OR t.description LIKE ?)";
+    $search_param = "%{$search_term}%";
+    $params[] = $search_param;
+    $params[] = $search_param;
+    $types .= 'ss';
+}
+
+$where_sql = implode(' AND ', $where_clauses);
+
+// Get total count for pagination
+$count_sql = "SELECT COUNT(*) as total FROM tickets t WHERE " . $where_sql;
+$count_stmt = $conn->prepare($count_sql);
+$count_stmt->bind_param($types, ...$params);
+$count_stmt->execute();
+$total_tickets = $count_stmt->get_result()->fetch_assoc()['total'];
+$total_pages = ceil($total_tickets / $per_page);
+
+// Get tickets with pagination
+$sql = "SELECT t.ticket_id, t.title, t.description, t.category, t.priority, t.status, 
+               t.created_at, t.last_activity, u.full_name as assigned_name,
+               (SELECT COUNT(*) FROM ticket_replies tr WHERE tr.ticket_id = t.ticket_id AND tr.is_internal = FALSE) as reply_count
+        FROM tickets t 
+        LEFT JOIN users u ON t.assigned_to = u.user_id 
+        WHERE " . $where_sql . "
+        ORDER BY t.last_activity DESC 
+        LIMIT ? OFFSET ?";
+
+$stmt = $conn->prepare($sql);
+$params[] = $per_page;
+$params[] = $offset;
+$types .= 'ii';
+$stmt->bind_param($types, ...$params);
+$stmt->execute();
+$result = $stmt->get_result();
+
+// Page header
+echo '<div class="page-header">';
+echo '<h1>My Tickets</h1>';
+echo '<a href="app.php?view=create_ticket" class="btn-create">Create New Ticket</a>';
+echo '</div>';
+
+// Filter and search bar
+echo '<div class="filter-bar">';
+
+// Search form
+echo '<form action="app.php" method="GET" class="search-form">';
+echo '    <input type="hidden" name="view" value="my_tickets">';
+if ($status_filter !== 'All') echo '    <input type="hidden" name="status" value="' . htmlspecialchars($status_filter) . '">';
+if ($category_filter !== 'All') echo '    <input type="hidden" name="category" value="' . htmlspecialchars($category_filter) . '">';
+echo '    <input type="text" name="search" placeholder="Search your tickets..." value="' . htmlspecialchars($search_term) . '">';
+echo '    <button type="submit">Search</button>';
+echo '</form>';
+
+// Filter pills container
+echo '<div class="filter-pills-container">';
+
+// Status filter pills
+echo '<div class="category-pills">';
+echo '<span class="filter-label">Status:</span>';
+$statuses = ['All', 'Open', 'In Progress', 'Resolved', 'Closed'];
+foreach ($statuses as $status) {
+    $url_params = [];
+    if ($category_filter !== 'All') $url_params[] = 'category=' . urlencode($category_filter);
+    if (!empty($search_term)) $url_params[] = 'search=' . urlencode($search_term);
+    if ($status !== 'All') $url_params[] = 'status=' . urlencode($status);
+    $url_params[] = 'view=my_tickets';
+    
+    $url = 'app.php?' . implode('&', $url_params);
+    $active_class = ($status_filter === $status) ? 'active' : '';
+    echo '<a href="' . $url . '" class="' . $active_class . '">' . htmlspecialchars($status) . '</a>';
+}
+echo '</div>';
+
+// Category filter pills
+echo '<div class="category-pills">';
+echo '<span class="filter-label">Category:</span>';
+$categories = ['All', 'Technical', 'Billing', 'General'];
+foreach ($categories as $category) {
+    $url_params = [];
+    if ($status_filter !== 'All') $url_params[] = 'status=' . urlencode($status_filter);
+    if (!empty($search_term)) $url_params[] = 'search=' . urlencode($search_term);
+    if ($category !== 'All') $url_params[] = 'category=' . urlencode($category);
+    $url_params[] = 'view=my_tickets';
+    
+    $url = 'app.php?' . implode('&', $url_params);
+    $active_class = ($category_filter === $category) ? 'active' : '';
+    echo '<a href="' . $url . '" class="' . $active_class . '">' . htmlspecialchars($category) . '</a>';
+}
+echo '</div>';
+
+echo '</div>'; // filter-pills-container
+echo '</div>'; // filter-bar
+
+// Results summary
+echo '<div class="results-summary">';
+if (!empty($search_term) || $status_filter !== 'All' || $category_filter !== 'All') {
+    echo '<p>Showing ' . $total_tickets . ' ticket' . ($total_tickets !== 1 ? 's' : '') . ' matching your filters';
+    if (!empty($search_term)) echo ' for "' . htmlspecialchars($search_term) . '"';
+    echo '</p>';
+} else {
+    echo '<p>You have ' . $total_tickets . ' ticket' . ($total_tickets !== 1 ? 's' : '') . ' total</p>';
+}
+echo '</div>';
+
+// Tickets list
+if ($result->num_rows > 0) {
+    echo '<div class="tickets-list">';
+    while ($row = $result->fetch_assoc()) {
+        echo '<div class="ticket-card">';
+        
+        // Ticket header with ID and title
+        echo '<div class="ticket-header">';
+        echo '<h3><a href="app.php?view=ticket&id=' . $row['ticket_id'] . '">#' . $row['ticket_id'] . ' - ' . htmlspecialchars($row['title']) . '</a></h3>';
+        echo '<div class="ticket-badges">';
+        echo '<span class="badge priority-' . strtolower($row['priority']) . '">' . htmlspecialchars($row['priority']) . '</span>';
+        echo '<span class="badge status-' . strtolower(str_replace(' ', '-', $row['status'])) . '">' . htmlspecialchars($row['status']) . '</span>';
+        echo '</div>';
+        echo '</div>';
+        
+        // Ticket meta information
+        echo '<div class="ticket-meta">';
+        echo '<span class="category category-' . strtolower($row['category']) . '">' . htmlspecialchars($row['category']) . '</span>';
+        echo '<span class="created-date">Created: ' . date('M j, Y g:i A', strtotime($row['created_at'])) . '</span>';
+        if ($row['last_activity'] !== $row['created_at']) {
+            echo '<span class="last-activity">Last activity: ' . date('M j, Y g:i A', strtotime($row['last_activity'])) . '</span>';
+        }
+        if ($row['assigned_name']) {
+            echo '<span class="assigned-to">Assigned to: ' . htmlspecialchars($row['assigned_name']) . '</span>';
+        }
+        echo '</div>';
+        
+        // Ticket description preview
+        echo '<div class="ticket-description">';
+        $description_preview = strlen($row['description']) > 200 ? 
+            substr($row['description'], 0, 200) . '...' : 
+            $row['description'];
+        echo '<p>' . nl2br(htmlspecialchars($description_preview)) . '</p>';
+        echo '</div>';
+        
+        // Ticket footer with reply count and actions
+        echo '<div class="ticket-footer">';
+        echo '<span class="reply-count">' . $row['reply_count'] . ' ' . ($row['reply_count'] == 1 ? 'reply' : 'replies') . '</span>';
+        echo '<a href="app.php?view=ticket&id=' . $row['ticket_id'] . '" class="btn-view-ticket">View Details</a>';
+        echo '</div>';
+        
+        echo '</div>'; // ticket-card
+    }
+    echo '</div>'; // tickets-list
+    
+    // Pagination
+    if ($total_pages > 1) {
+        echo '<div class="pagination">';
+        
+        // Build base URL for pagination
+        $base_params = [];
+        $base_params[] = 'view=my_tickets';
+        if ($status_filter !== 'All') $base_params[] = 'status=' . urlencode($status_filter);
+        if ($category_filter !== 'All') $base_params[] = 'category=' . urlencode($category_filter);
+        if (!empty($search_term)) $base_params[] = 'search=' . urlencode($search_term);
+        $base_url = 'app.php?' . implode('&', $base_params);
+        
+        // Previous page
+        if ($page > 1) {
+            echo '<a href="' . $base_url . '&page=' . ($page - 1) . '" class="pagination-link">&laquo; Previous</a>';
+        }
+        
+        // Page numbers
+        $start_page = max(1, $page - 2);
+        $end_page = min($total_pages, $page + 2);
+        
+        if ($start_page > 1) {
+            echo '<a href="' . $base_url . '&page=1" class="pagination-link">1</a>';
+            if ($start_page > 2) echo '<span class="pagination-ellipsis">...</span>';
+        }
+        
+        for ($i = $start_page; $i <= $end_page; $i++) {
+            if ($i == $page) {
+                echo '<span class="pagination-link active">' . $i . '</span>';
+            } else {
+                echo '<a href="' . $base_url . '&page=' . $i . '" class="pagination-link">' . $i . '</a>';
+            }
+        }
+        
+        if ($end_page < $total_pages) {
+            if ($end_page < $total_pages - 1) echo '<span class="pagination-ellipsis">...</span>';
+            echo '<a href="' . $base_url . '&page=' . $total_pages . '" class="pagination-link">' . $total_pages . '</a>';
+        }
+        
+        // Next page
+        if ($page < $total_pages) {
+            echo '<a href="' . $base_url . '&page=' . ($page + 1) . '" class="pagination-link">Next &raquo;</a>';
+        }
+        
+        echo '</div>'; // pagination
+    }
+    
+} else {
+    // No tickets found
+    echo '<div class="no-tickets">';
+    if (!empty($search_term) || $status_filter !== 'All' || $category_filter !== 'All') {
+        echo '<p>No tickets found matching your search criteria.</p>';
+        echo '<p><a href="app.php?view=my_tickets">View all tickets</a> or <a href="app.php?view=create_ticket">create a new ticket</a>.</p>';
+    } else {
+        echo '<p>You haven\'t created any tickets yet.</p>';
+        echo '<p><a href="app.php?view=create_ticket" class="btn-create">Create your first ticket</a> to get started.</p>';
+    }
+    echo '</div>';
+}
+?>

--- a/Helpdesk/views/post.php
+++ b/Helpdesk/views/post.php
@@ -1,0 +1,57 @@
+<?php
+// This file is views/post.php
+
+require 'connector.php';
+$post_id = $_GET['id'] ?? 0;
+
+// Fetch the post
+$sql_post = "SELECT p.title, p.content, p.created_at, u.user_name FROM posts p JOIN user u ON p.author_id = u.user_id WHERE p.post_id = ?";
+$stmt_post = $conn->prepare($sql_post);
+$stmt_post->bind_param("i", $post_id);
+$stmt_post->execute();
+$result_post = $stmt_post->get_result();
+
+if ($result_post->num_rows == 1) {
+    $post = $result_post->fetch_assoc();
+    echo '<a href="app.php?view=posts">&larr; Back to Posts</a>';
+    echo '<h1>' . htmlspecialchars($post['title']) . '</h1>';
+    echo '<p class="post-meta">By ' . htmlspecialchars($post['user_name']) . ' on ' . date('F j, Y', strtotime($post['created_at'])) . '</p>';
+    echo '<div class="post-content">' . nl2br(htmlspecialchars($post['content'])) . '</div>';
+
+    // Fetch replies
+    $sql_replies = "SELECT r.content, r.created_at, u.user_name FROM replies r JOIN user u ON r.author_id = u.user_id WHERE r.post_id = ? ORDER BY r.created_at ASC";
+    $stmt_replies = $conn->prepare($sql_replies);
+    $stmt_replies->bind_param("i", $post_id);
+    $stmt_replies->execute();
+    $result_replies = $stmt_replies->get_result();
+
+    // Replies section
+    echo '<hr class="post-divider">';
+    echo '<h2>Replies</h2>';
+
+    if ($result_replies->num_rows > 0) {
+        echo '<div class="replies-list">';
+        while($reply = $result_replies->fetch_assoc()) {
+            echo '<div class="reply-card">';
+            echo '<p class="reply-meta"><strong>' . htmlspecialchars($reply['user_name']) . '</strong><span class="reply-date"> on ' . date('F j, Y', strtotime($reply['created_at'])) . '</span></p>';
+            echo '<p>' . nl2br(htmlspecialchars($reply['content'])) . '</p>';
+            echo '</div>';
+        }
+        echo '</div>';
+    } else {
+        echo '<p>No replies yet.</p>';
+    }
+    
+    if (isset($_SESSION['user_id'])) {
+        echo '<form action="actions/add_reply.php" method="POST" class="reply-form">';
+        echo '    <input type="hidden" name="post_id" value="' . htmlspecialchars($post_id) . '">';
+        echo '    <textarea name="reply_content" placeholder="Write a reply..." required></textarea>';
+        echo '    <button type="submit">Post</button>';
+        echo '</form>';
+    } else {
+        echo '<p><a href="login.php">Log in</a> to leave a reply.</p>';
+    }
+
+} else {
+    echo '<h1>Post not found</h1>';
+}

--- a/Helpdesk/views/posts.php
+++ b/Helpdesk/views/posts.php
@@ -1,0 +1,94 @@
+<?php
+// This file is views/posts.php
+
+echo '<div class="page-header">';
+echo '<h1>Posts</h1>';
+if (isset($_SESSION['user_type']) && in_array($_SESSION['user_type'], ['ADMIN', 'MEMBER'])) {
+    echo '<a href="app.php?view=create_post" class="btn-create">New Post</a>';
+}
+echo '</div>';
+
+require 'connector.php';
+
+// Fetch categories for filter pills
+$categories_sql = "SELECT DISTINCT category FROM posts ORDER BY category ASC";
+$categories_result = $conn->query($categories_sql);
+$current_category = $_GET['category'] ?? 'All';
+$search_term = $_GET['search'] ?? '';
+
+// --- Filter Bar (Search and Categories) ---
+echo '<div class="filter-bar">';
+// Search Form
+echo '<form action="app.php" method="GET" class="search-form">';
+echo '    <input type="hidden" name="view" value="posts">';
+echo '    <input type="text" name="search" placeholder="Search posts..." value="' . htmlspecialchars($search_term) . '">';
+echo '    <button type="submit">Search</button>';
+echo '</form>';
+
+// Category Pills
+echo '<div class="category-pills">';
+echo '<a href="app.php?view=posts" class="' . ($current_category === 'All' ? 'active' : '') . '">All</a>';
+if ($categories_result->num_rows > 0) {
+    while($cat_row = $categories_result->fetch_assoc()) {
+        $category = htmlspecialchars($cat_row['category']);
+        echo '<a href="app.php?view=posts&category=' . urlencode($category) . '" class="' . ($current_category === $category ? 'active' : '') . '">' . $category . '</a>';
+    }
+}
+echo '</div>';
+echo '</div>';
+
+
+// --- Fetch Posts (with filtering) ---
+$sql = "SELECT p.post_id, p.title, p.content, p.created_at, p.author_id, u.user_name FROM posts p JOIN user u ON p.author_id = u.user_id";
+$params = [];
+$types = '';
+
+$where_clauses = [];
+if ($current_category !== 'All') {
+    $where_clauses[] = "p.category = ?";
+    $params[] = $current_category;
+    $types .= 's';
+}
+if (!empty($search_term)) {
+    $where_clauses[] = "(p.title LIKE ? OR p.content LIKE ?)";
+    $search_param = "%{$search_term}%";
+    $params[] = $search_param;
+    $params[] = $search_param;
+    $types .= 'ss';
+}
+
+if (!empty($where_clauses)) {
+    $sql .= " WHERE " . implode(' AND ', $where_clauses);
+}
+
+$sql .= " ORDER BY p.created_at DESC";
+
+$stmt = $conn->prepare($sql);
+if (!empty($params)) {
+    $stmt->bind_param($types, ...$params);
+}
+$stmt->execute();
+$result = $stmt->get_result();
+
+if ($result->num_rows > 0) {
+    echo '<div class="posts-list">';
+    while($row = $result->fetch_assoc()) {
+        echo '<div class="post-card">';
+        echo '<h2>' . htmlspecialchars($row['title']) . '</h2>';
+        echo '<p class="post-meta">By ' . htmlspecialchars($row['user_name']) . ' on ' . date('F j, Y', strtotime($row['created_at'])) . '</p>';
+        echo '<p>' . nl2br(htmlspecialchars(substr($row['content'], 0, 150))) . '...</p>';
+        echo '<a href="app.php?view=post&id=' . $row['post_id'] . '" class="btn-reply">View Post</a>';
+        
+        // Edit/Delete buttons for author/admin
+        if (isset($_SESSION['user_id']) && ($_SESSION['user_id'] == $row['author_id'] || $_SESSION['user_type'] === 'ADMIN')) {
+            echo '<div class="post-actions">';
+            echo '<a href="app.php?view=edit_post&id=' . $row['post_id'] . '" class="post-action-btn">Edit</a>';
+            echo '<a href="actions/delete_post.php?id=' . $row['post_id'] . '" class="post-action-btn btn-delete" onclick="return confirm(\'Are you sure you want to delete this post?\');">Delete</a>';
+            echo '</div>';
+        }
+        echo '</div>';
+    }
+    echo '</div>';
+} else {
+    echo '<p>No posts found.</p>';
+}

--- a/Helpdesk/views/ticket.php
+++ b/Helpdesk/views/ticket.php
@@ -1,0 +1,248 @@
+<?php
+// This file is views/ticket.php - Individual ticket detail view
+
+require 'connector.php';
+
+// Display success/error messages
+if (isset($_SESSION['success'])) {
+    echo '<div class="success-message">' . htmlspecialchars($_SESSION['success']) . '</div>';
+    unset($_SESSION['success']);
+}
+
+if (isset($_SESSION['error'])) {
+    echo '<div class="error-message">' . htmlspecialchars($_SESSION['error']) . '</div>';
+    unset($_SESSION['error']);
+}
+
+// Get ticket ID from URL parameter
+$ticket_id = intval($_GET['id'] ?? 0);
+
+if (!$ticket_id) {
+    echo '<div class="error-message">Invalid ticket ID.</div>';
+    return;
+}
+
+// Get ticket details with user information
+$sql = "SELECT t.*, 
+               customer.full_name as customer_name, customer.email as customer_email,
+               assigned.full_name as assigned_name
+        FROM tickets t 
+        LEFT JOIN users customer ON t.customer_id = customer.user_id
+        LEFT JOIN users assigned ON t.assigned_to = assigned.user_id
+        WHERE t.ticket_id = ?";
+
+$stmt = $conn->prepare($sql);
+$stmt->bind_param('i', $ticket_id);
+$stmt->execute();
+$result = $stmt->get_result();
+
+if ($result->num_rows === 0) {
+    echo '<div class="error-message">Ticket not found.</div>';
+    return;
+}
+
+$ticket = $result->fetch_assoc();
+
+// Check access permissions
+$can_view = false;
+if ($_SESSION['user_role'] === 'ADMIN') {
+    $can_view = true; // Admins can view all tickets
+} elseif ($_SESSION['user_role'] === 'CUSTOMER' && $ticket['customer_id'] == $_SESSION['user_id']) {
+    $can_view = true; // Customers can only view their own tickets
+}
+
+if (!$can_view) {
+    echo '<div class="error-message">You do not have permission to view this ticket.</div>';
+    return;
+}
+
+// Get ticket replies with user information
+$replies_sql = "SELECT tr.*, u.full_name, u.user_role
+                FROM ticket_replies tr
+                JOIN users u ON tr.author_id = u.user_id
+                WHERE tr.ticket_id = ? 
+                AND (tr.is_internal = FALSE OR ? = 'ADMIN')
+                ORDER BY tr.created_at ASC";
+
+$replies_stmt = $conn->prepare($replies_sql);
+$replies_stmt->bind_param('is', $ticket_id, $_SESSION['user_role']);
+$replies_stmt->execute();
+$replies_result = $replies_stmt->get_result();
+
+// Get attachments for the ticket
+$attachments_sql = "SELECT * FROM attachments WHERE ticket_id = ? ORDER BY created_at ASC";
+$attachments_stmt = $conn->prepare($attachments_sql);
+$attachments_stmt->bind_param('i', $ticket_id);
+$attachments_stmt->execute();
+$attachments_result = $attachments_stmt->get_result();
+
+?>
+
+<div class="ticket-detail-container">
+    <!-- Ticket Header -->
+    <div class="ticket-detail-header">
+        <div class="ticket-title-section">
+            <h1>#<?= $ticket['ticket_id'] ?> - <?= htmlspecialchars($ticket['title']) ?></h1>
+            <div class="ticket-badges">
+                <span class="badge priority-<?= strtolower($ticket['priority']) ?>"><?= htmlspecialchars($ticket['priority']) ?></span>
+                <span class="badge status-<?= strtolower(str_replace(' ', '-', $ticket['status'])) ?>"><?= htmlspecialchars($ticket['status']) ?></span>
+                <span class="badge category-<?= strtolower($ticket['category']) ?>"><?= htmlspecialchars($ticket['category']) ?></span>
+            </div>
+        </div>
+        
+        <div class="ticket-actions">
+            <?php if ($_SESSION['user_role'] === 'CUSTOMER'): ?>
+                <a href="app.php?view=my_tickets" class="btn-back">← Back to My Tickets</a>
+            <?php else: ?>
+                <a href="app.php?view=tickets" class="btn-back">← Back to All Tickets</a>
+            <?php endif; ?>
+        </div>
+    </div>
+
+    <!-- Ticket Meta Information -->
+    <div class="ticket-meta-section">
+        <div class="meta-item">
+            <strong>Customer:</strong> <?= htmlspecialchars($ticket['customer_name']) ?> (<?= htmlspecialchars($ticket['customer_email']) ?>)
+        </div>
+        <div class="meta-item">
+            <strong>Created:</strong> <?= date('M j, Y g:i A', strtotime($ticket['created_at'])) ?>
+        </div>
+        <div class="meta-item">
+            <strong>Last Activity:</strong> <?= date('M j, Y g:i A', strtotime($ticket['last_activity'])) ?>
+        </div>
+        <?php if ($ticket['assigned_name']): ?>
+        <div class="meta-item">
+            <strong>Assigned to:</strong> <?= htmlspecialchars($ticket['assigned_name']) ?>
+        </div>
+        <?php endif; ?>
+    </div>
+
+    <!-- Original Ticket Content -->
+    <div class="ticket-content-section">
+        <h3>Original Request</h3>
+        <div class="ticket-content">
+            <?= nl2br(htmlspecialchars($ticket['description'])) ?>
+        </div>
+        
+        <!-- Original Ticket Attachments -->
+        <?php if ($attachments_result->num_rows > 0): ?>
+        <div class="attachments-section">
+            <h4>Attachments</h4>
+            <div class="attachments-list">
+                <?php while ($attachment = $attachments_result->fetch_assoc()): ?>
+                    <div class="attachment-item">
+                        <a href="actions/download_file.php?id=<?= $attachment['attachment_id'] ?>" class="attachment-link">
+                            📎 <?= htmlspecialchars($attachment['original_filename']) ?>
+                        </a>
+                        <span class="attachment-size">(<?= number_format($attachment['file_size'] / 1024, 1) ?> KB)</span>
+                    </div>
+                <?php endwhile; ?>
+            </div>
+        </div>
+        <?php endif; ?>
+    </div>
+
+    <!-- Replies Section -->
+    <?php if ($replies_result->num_rows > 0): ?>
+    <div class="replies-section">
+        <h3>Conversation History</h3>
+        <div class="replies-list">
+            <?php while ($reply = $replies_result->fetch_assoc()): ?>
+            <div class="reply-item <?= $reply['is_internal'] ? 'internal-note' : 'public-reply' ?>">
+                <div class="reply-header">
+                    <div class="reply-author">
+                        <strong><?= htmlspecialchars($reply['full_name']) ?></strong>
+                        <?php if ($reply['user_role'] === 'ADMIN'): ?>
+                            <span class="role-badge admin">Support Agent</span>
+                        <?php else: ?>
+                            <span class="role-badge customer">Customer</span>
+                        <?php endif; ?>
+                        <?php if ($reply['is_internal']): ?>
+                            <span class="internal-badge">Internal Note</span>
+                        <?php endif; ?>
+                    </div>
+                    <div class="reply-date">
+                        <?= date('M j, Y g:i A', strtotime($reply['created_at'])) ?>
+                    </div>
+                </div>
+                <div class="reply-content">
+                    <?= nl2br(htmlspecialchars($reply['content'])) ?>
+                </div>
+                
+                <!-- Reply Attachments -->
+                <?php
+                $reply_attachments_sql = "SELECT * FROM attachments WHERE reply_id = ? ORDER BY created_at ASC";
+                $reply_attachments_stmt = $conn->prepare($reply_attachments_sql);
+                $reply_attachments_stmt->bind_param('i', $reply['reply_id']);
+                $reply_attachments_stmt->execute();
+                $reply_attachments_result = $reply_attachments_stmt->get_result();
+                
+                if ($reply_attachments_result->num_rows > 0): ?>
+                <div class="reply-attachments">
+                    <?php while ($reply_attachment = $reply_attachments_result->fetch_assoc()): ?>
+                        <div class="attachment-item">
+                            <a href="actions/download_file.php?id=<?= $reply_attachment['attachment_id'] ?>" class="attachment-link">
+                                📎 <?= htmlspecialchars($reply_attachment['original_filename']) ?>
+                            </a>
+                            <span class="attachment-size">(<?= number_format($reply_attachment['file_size'] / 1024, 1) ?> KB)</span>
+                        </div>
+                    <?php endwhile; ?>
+                </div>
+                <?php endif; ?>
+            </div>
+            <?php endwhile; ?>
+        </div>
+    </div>
+    <?php endif; ?>
+
+    <!-- Reply Form -->
+    <?php if ($ticket['status'] !== 'Closed'): ?>
+    <div class="reply-form-section">
+        <h3>Add Reply</h3>
+        <form action="actions/add_reply.php" method="POST" enctype="multipart/form-data" class="reply-form">
+            <input type="hidden" name="ticket_id" value="<?= $ticket['ticket_id'] ?>">
+            
+            <div class="form-group">
+                <label for="content">Your Reply <span class="required">*</span></label>
+                <textarea name="content" id="content" required placeholder="Enter your reply..."></textarea>
+            </div>
+            
+            <?php if ($_SESSION['user_role'] === 'ADMIN'): ?>
+            <div class="form-group">
+                <label>
+                    <input type="checkbox" name="is_internal" value="1">
+                    Internal Note (only visible to support agents)
+                </label>
+            </div>
+            <?php endif; ?>
+            
+            <div class="form-group">
+                <label for="attachment">Attach File (optional)</label>
+                <input type="file" name="attachment" id="attachment" accept=".jpg,.jpeg,.png,.gif,.pdf,.doc,.docx,.txt">
+                <small class="file-help">Maximum file size: 5MB. Allowed types: images, PDF, Word documents, text files.</small>
+            </div>
+            
+            <div class="form-actions">
+                <button type="submit" class="btn-submit">Add Reply</button>
+            </div>
+        </form>
+    </div>
+    <?php else: ?>
+    <div class="ticket-closed-notice">
+        <p><strong>This ticket is closed.</strong> No further replies can be added.</p>
+    </div>
+    <?php endif; ?>
+</div>
+
+<script>
+// Auto-resize textarea
+document.addEventListener('DOMContentLoaded', function() {
+    const textarea = document.getElementById('content');
+    if (textarea) {
+        textarea.addEventListener('input', function() {
+            this.style.height = 'auto';
+            this.style.height = this.scrollHeight + 'px';
+        });
+    }
+});
+</script>

--- a/Helpdesk/views/users.php
+++ b/Helpdesk/views/users.php
@@ -1,0 +1,35 @@
+<?php
+// This file is views/users.php
+
+// Check for admin privileges
+if (isset($_SESSION['user_type']) && $_SESSION['user_type'] === 'ADMIN') {
+    echo '<h1>Manage Users</h1>';
+    
+    require 'connector.php';
+    $sql = "SELECT user_id, user_name, user_type FROM user";
+    $result = $conn->query($sql);
+
+    if ($result->num_rows > 0) {
+        echo '<table class="user-table">';
+        echo '<thead><tr><th>ID</th><th>Username</th><th>Role</th><th>Actions</th></tr></thead>';
+        echo '<tbody>';
+        while($row = $result->fetch_assoc()) {
+            echo '<tr>';
+            echo '<td>' . $row['user_id'] . '</td>';
+            echo '<td>' . htmlspecialchars($row['user_name']) . '</td>';
+            echo '<td>' . htmlspecialchars($row['user_type']) . '</td>';
+            echo '<td>';
+            echo '<a href="app.php?view=edit_user&id=' . $row['user_id'] . '" class="btn-action">Edit</a> ';
+            echo '<a href="actions/delete_user.php?id=' . $row['user_id'] . '" class="btn-action btn-delete" onclick="return confirm(\'Are you sure you want to delete this user?\');">Delete</a>';
+            echo '</td>';
+            echo '</tr>';
+        }
+        echo '</tbody>';
+        echo '</table>';
+    } else {
+        echo '<p>No users found.</p>';
+    }
+
+} else {
+    echo '<h1>Access Denied</h1>';
+}


### PR DESCRIPTION
Add a new Helpdesk/signup.php that implements a full sign-up flow:
- renders a signup form (username, email, full name, password, confirm password) styled via login.css
- performs server-side validation for required fields, lengths, email format, password length, and password confirmation
- checks for existing username/email and inserts a new user with a default CUSTOMER role when validation passes
- starts a session, stores user data in session, and redirects to app.php on successful registration
- includes client-side scaffolding for real-time validation

These changes provide a complete user registration path and prevent invalid or duplicate accounts by validating input before insertion.