### PR TITLE
feat: add post, reply, profile edit, create/delete actions

### DIFF
--- a/NotionForum/README.md
+++ b/NotionForum/README.md
@@ -1,0 +1,87 @@
+# Community Bulletin & Forum
+
+## Overview
+
+Community Bulletin & Forum is a PHP-based platform for community interaction and information sharing. It allows community members to create bulletin posts, start forum discussions, and engage in conversations across different categories.
+
+## Features
+
+- Create bulletin posts for announcements, events, and marketplace items
+- Start and participate in forum discussions
+- Organize content by categories (General, Events, Marketplace, Discussions)
+- User authentication and profile management
+- Admin panel for content and user management
+- Reply system for forum topics
+- Simple and clean community-focused interface
+
+## Getting Started
+
+### Prerequisites
+
+- PHP 7.0 or higher
+- A web server (e.g., Apache, Nginx)
+- MySQL or compatible database (if using database features)
+
+### Installation
+
+1. **Download or clone the repository:**
+   - Download the project files to your web server directory
+   - Ensure all files are in the correct structure as shown in the File Structure section
+2. **Copy files to your web server directory.**
+
+3. **Configure database connection:**
+   - Create a `connector.php` file in the project root with the following content:
+     ```php
+     <?php
+
+     $dbServerName = "localhost";
+     $dbUserName = "root";
+     $dbPassword = "";
+     $dbName = "community_bulletin_db";
+
+     $conn = mysqli_connect($dbServerName, $dbUserName, $dbPassword, $dbName);
+
+     if ($conn->connect_error) {
+         die("Connection Failed" . $conn->connect_error);
+     }
+     ?>
+     ```
+   - Update the database credentials in `connector.php` if your setup is different.
+
+4. **Set appropriate permissions:**
+   - Ensure the web server can write to any upload or cache directories if used.
+
+### Usage
+
+- Access the application via your web browser at `http://localhost/8000` or your server's URL.
+- Register as a community member to create posts and participate in discussions.
+- Admins can manage all content and users through the admin panel.
+
+## File Structure
+
+- `index.php` - Main entry point (redirects to community home)
+- `home/community.php` - Community bulletin and forum home page
+- `home/forum-topic.php` - Individual forum topic view with replies
+- `writer/` - Community member interface for creating and managing posts
+- `admin/` - Administrative interface for content and user management
+- `connector.php` - Database configuration file
+- `community_bulletin_db.sql` - Database schema
+- `.gitignore` - Git ignore rules
+
+## Categories
+
+The platform supports four main content categories:
+- **General**: Community announcements and general information
+- **Events**: Community events, meetings, and activities
+- **Marketplace**: Buy/sell/trade items within the community
+- **Discussions**: Open discussions and questions
+
+## Design Notes
+
+The platform uses a modern, image-free design with:
+- Gradient backgrounds instead of image dependencies
+- Category-based color coding for visual organization
+- Clean, text-focused content presentation
+- Responsive design that works on all devices
+
+

--- a/NotionForum/actions/add_reply.php
+++ b/NotionForum/actions/add_reply.php
@@ -1,0 +1,20 @@
+<?php
+// This file is actions/add_reply.php
+
+session_start();
+require '../connector.php';
+
+if (isset($_SESSION['user_id'])) {
+    $content = $_POST['reply_content'];
+    $post_id = $_POST['post_id'];
+    $author_id = $_SESSION['user_id'];
+
+    $sql = "INSERT INTO replies (post_id, content, author_id) VALUES (?, ?, ?)";
+    $stmt = $conn->prepare($sql);
+    $stmt->bind_param("isi", $post_id, $content, $author_id);
+    $stmt->execute();
+
+    // Redirect back to the post view
+    header("Location: ../app.php?view=post&id=" . $post_id);
+    exit();
+}

--- a/NotionForum/actions/create_post.php
+++ b/NotionForum/actions/create_post.php
@@ -1,0 +1,26 @@
+<?php
+// This file is actions/create_post.php
+
+session_start();
+require '../connector.php';
+
+if (isset($_SESSION['user_id']) && in_array($_SESSION['user_type'], ['ADMIN', 'MEMBER'])) {
+    $title = $_POST['title'];
+    $content = $_POST['content'];
+    $category = $_POST['category'];
+    if ($category === 'Other') {
+        $category = $_POST['new_category'];
+    }
+    $author_id = $_SESSION['user_id'];
+    // For simplicity, we'll hardcode post_type. This could be a form field.
+    $post_type = 'FORUM'; 
+
+    $sql = "INSERT INTO posts (title, content, author_id, post_type, category) VALUES (?, ?, ?, ?, ?)";
+    $stmt = $conn->prepare($sql);
+    $stmt->bind_param("ssiss", $title, $content, $author_id, $post_type, $category);
+    $stmt->execute();
+
+    // Redirect to the main posts view
+    header("Location: ../app.php?view=posts");
+    exit();
+}

--- a/NotionForum/actions/delete_post.php
+++ b/NotionForum/actions/delete_post.php
@@ -1,0 +1,28 @@
+<?php
+// This file is actions/delete_post.php
+
+session_start();
+require '../connector.php';
+
+if (isset($_SESSION['user_id'])) {
+    $post_id = $_GET['id'] ?? 0;
+    if ($post_id > 0) {
+        // Check if user is author or admin
+        $sql_check = "SELECT author_id FROM posts WHERE post_id = ?";
+        $stmt_check = $conn->prepare($sql_check);
+        $stmt_check->bind_param("i", $post_id);
+        $stmt_check->execute();
+        $result_check = $stmt_check->get_result();
+        if ($result_check->num_rows == 1) {
+            $post_data = $result_check->fetch_assoc();
+            if ($post_data['author_id'] == $_SESSION['user_id'] || $_SESSION['user_type'] === 'ADMIN') {
+                $sql = "DELETE FROM posts WHERE post_id = ?";
+                $stmt = $conn->prepare($sql);
+                $stmt->bind_param("i", $post_id);
+                $stmt->execute();
+            }
+        }
+    }
+}
+header("Location: ../app.php?view=posts");
+exit();

--- a/NotionForum/actions/delete_user.php
+++ b/NotionForum/actions/delete_user.php
@@ -1,0 +1,17 @@
+<?php
+// This file is actions/delete_user.php
+
+session_start();
+require '../connector.php';
+
+if (isset($_SESSION['user_type']) && $_SESSION['user_type'] === 'ADMIN') {
+    $user_id = $_GET['id'] ?? 0;
+    if ($user_id > 0) {
+        $sql = "DELETE FROM user WHERE user_id = ?";
+        $stmt = $conn->prepare($sql);
+        $stmt->bind_param("i", $user_id);
+        $stmt->execute();
+    }
+}
+header("Location: ../app.php?view=users");
+exit();

--- a/NotionForum/actions/update_post.php
+++ b/NotionForum/actions/update_post.php
@@ -1,0 +1,33 @@
+<?php
+// This file is actions/update_post.php
+
+session_start();
+require '../connector.php';
+
+if (isset($_SESSION['user_id'])) {
+    $post_id = $_POST['post_id'];
+    $title = $_POST['title'];
+    $content = $_POST['content'];
+    $category = $_POST['category'];
+    if ($category === 'Other') {
+        $category = $_POST['new_category'];
+    }
+
+    // Check if user is author or admin
+    $sql_check = "SELECT author_id FROM posts WHERE post_id = ?";
+    $stmt_check = $conn->prepare($sql_check);
+    $stmt_check->bind_param("i", $post_id);
+    $stmt_check->execute();
+    $result_check = $stmt_check->get_result();
+    if ($result_check->num_rows == 1) {
+        $post_data = $result_check->fetch_assoc();
+        if ($post_data['author_id'] == $_SESSION['user_id'] || $_SESSION['user_type'] === 'ADMIN') {
+            $sql = "UPDATE posts SET title = ?, content = ?, category = ? WHERE post_id = ?";
+            $stmt = $conn->prepare($sql);
+            $stmt->bind_param("sssi", $title, $content, $category, $post_id);
+            $stmt->execute();
+        }
+    }
+}
+header("Location: ../app.php?view=post&id=" . $post_id);
+exit();

--- a/NotionForum/actions/update_profile.php
+++ b/NotionForum/actions/update_profile.php
@@ -1,0 +1,40 @@
+<?php
+// This file is actions/update_profile.php
+
+session_start();
+require '../connector.php';
+
+if (!isset($_SESSION['user_id'])) {
+    header("Location: ../login.php");
+    exit();
+}
+
+$user_id = $_SESSION['user_id'];
+$user_name = $_POST['user_name'];
+$password = $_POST['password'];
+
+// Start building the SQL query
+$sql = "UPDATE user SET user_name = ? ";
+$types = "s";
+$params = [$user_name];
+
+// Add password to update if provided
+if (!empty($password)) {
+    $sql .= ", pass = ? ";
+    $types .= "s";
+    $params[] = $password;
+}
+
+$sql .= " WHERE user_id = ?";
+$types .= "i";
+$params[] = $user_id;
+
+$stmt = $conn->prepare($sql);
+$stmt->bind_param($types, ...$params);
+$stmt->execute();
+
+// Update session username if it changed
+$_SESSION['user_name'] = $user_name;
+
+header("Location: ../app.php?view=edit_profile&status=success");
+exit();

--- a/NotionForum/actions/update_user.php
+++ b/NotionForum/actions/update_user.php
@@ -1,0 +1,18 @@
+<?php
+// This file is actions/update_user.php
+
+session_start();
+require '../connector.php';
+
+if (isset($_SESSION['user_type']) && $_SESSION['user_type'] === 'ADMIN') {
+    $user_id = $_POST['user_id'];
+    $user_name = $_POST['user_name'];
+    $user_type = $_POST['user_type'];
+
+    $sql = "UPDATE user SET user_name = ?, user_type = ? WHERE user_id = ?";
+    $stmt = $conn->prepare($sql);
+    $stmt->bind_param("ssi", $user_name, $user_type, $user_id);
+    $stmt->execute();
+}
+header("Location: ../app.php?view=users");
+exit();

--- a/NotionForum/app.php
+++ b/NotionForum/app.php
@@ -1,0 +1,84 @@
+
+<?php
+session_start();
+
+require 'connector.php';
+
+// Fetch distinct categories for select inputs
+$all_categories = [];
+$categories_sql = "SELECT DISTINCT category FROM posts ORDER BY category ASC";
+$categories_result = $conn->query($categories_sql);
+if ($categories_result->num_rows > 0) {
+    while($row = $categories_result->fetch_assoc()) {
+        $all_categories[] = $row['category'];
+    }
+}
+
+$view = $_GET['view'] ?? 'posts'; // Default view
+
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Forum</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+
+    <nav class="top-nav">
+        <div class="nav-container">
+            <a href="app.php" class="nav-brand">Forum </a>
+            <ul class="nav-links">
+                <li><a href="app.php?view=posts" class="<?= ($view === 'posts' || $view === 'post') ? 'active' : '' ?>">Posts</a></li>
+                <?php if (isset($_SESSION['user_type']) && $_SESSION['user_type'] === 'ADMIN'): ?>
+                    <li><a href="app.php?view=users" class="<?= ($view === 'users') ? 'active' : '' ?>">Manage Users</a></li>
+                <?php endif; ?>
+            </ul>
+            <ul class="nav-user">
+                <?php if (isset($_SESSION['user_id'])): ?>
+                    <li><a href="app.php?view=edit_profile" class="<?= ($view === 'edit_profile') ? 'active' : '' ?>">Edit Profile</a></li>
+                    <li><a href="logout.php" class="btn-signup">Logout</a></li>
+                <?php else: ?>
+                    <li><a href="login.php" class="btn-signup" style="margin-right: 5px">Login</a></li>
+                    <li><a href="signup.php" class="btn-signup">Sign Up</a></li>
+                <?php endif; ?>
+            </ul>
+        </div>
+    </nav>
+
+    <div class="main-container">
+        <div class="container">
+            <?php
+            // Based on the view parameter, include the corresponding content
+            switch ($view) {
+                case 'users':
+                    require 'views/users.php';
+                    break;
+                case 'post':
+                    require 'views/post.php';
+                    break;
+                case 'edit_user':
+                    require 'views/edit_user.php';
+                break;
+                case 'edit_profile':
+                    require 'views/edit_profile.php';
+                break;
+                case 'edit_post':
+                    require 'views/edit_post.php';
+                    break;
+                case 'create_post':
+                    require 'views/create_post.php';
+                    break;
+                case 'posts':
+                default:
+                    require 'views/posts.php';
+                    break;
+            }
+            ?>
+        </div>
+    </div>
+
+</body>
+</html>

--- a/NotionForum/connector.php
+++ b/NotionForum/connector.php
@@ -1,0 +1,12 @@
+<?php
+
+$dbServerName = "localhost";
+$dbUserName = "root";
+$dbPassword = "deliquescent";
+$dbName = "forum_db";
+
+$conn = mysqli_connect($dbServerName, $dbUserName, $dbPassword, $dbName);
+
+if ($conn->connect_error) {
+    die("Connection Failed" . $conn->connect_error);
+}

--- a/NotionForum/index.php
+++ b/NotionForum/index.php
@@ -1,0 +1,4 @@
+<?php
+// Redirect to the main application page
+header("Location: app.php");
+exit();

--- a/NotionForum/login.css
+++ b/NotionForum/login.css
@@ -1,0 +1,84 @@
+
+:root {
+    --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    --bg-color: #FFFFFF;
+    --border-color: #E5E5E5;
+    --text-color: #333333;
+    --text-secondary-color: #888888;
+    --accent-color: #2E6DA4;
+}
+
+body {
+    font-family: var(--font-sans);
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    margin: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+}
+
+.login-container {
+    width: 320px;
+    padding: 40px;
+    background-color: #fff;
+    border-radius: 8px;
+    border: 1px solid var(--border-color);
+}
+
+h1 {
+    text-align: center;
+    font-size: 1.5em;
+    margin-bottom: 20px;
+}
+
+.form-group {
+    margin-bottom: 15px;
+}
+
+label {
+    display: block;
+    margin-bottom: 5px;
+    font-weight: 500;
+    color: var(--text-secondary-color);
+}
+
+input[type="text"], input[type="password"] {
+    width: 100%;
+    padding: 10px;
+    border: 1px solid var(--border-color);
+    border-radius: 5px;
+    box-sizing: border-box; /* Important */
+}
+
+button {
+    width: 100%;
+    padding: 10px;
+    background-color: var(--accent-color);
+    color: white;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 1em;
+}
+
+button:hover {
+    background-color: #204d74;
+}
+
+.message {
+    text-align: center;
+    margin-bottom: 15px;
+    color: red;
+}
+
+.signup-link {
+    text-align: center;
+    margin-top: 20px;
+}
+
+.signup-link a {
+    color: var(--accent-color);
+    text-decoration: none;
+}

--- a/NotionForum/login.php
+++ b/NotionForum/login.php
@@ -1,0 +1,68 @@
+
+<?php
+session_start();
+
+// If user is already logged in, redirect to app.php
+if (isset($_SESSION['user_id'])) {
+    header("Location: app.php");
+    exit();
+}
+
+require 'connector.php';
+
+$message = '';
+
+if ($_SERVER["REQUEST_METHOD"] == "POST") {
+    $username = $_POST['username'];
+    $password = $_POST['password'];
+
+    $sql = "SELECT * FROM user WHERE user_name = ? AND pass = ?";
+    $stmt = $conn->prepare($sql);
+    $stmt->bind_param("ss", $username, $password);
+    $stmt->execute();
+    $result = $stmt->get_result();
+
+    if ($result->num_rows == 1) {
+        $user = $result->fetch_assoc();
+        $_SESSION['user_id'] = $user['user_id'];
+        $_SESSION['user_name'] = $user['user_name'];
+        $_SESSION['user_type'] = $user['user_type'];
+        header("Location: app.php");
+        exit();
+    } else {
+        $message = "Invalid username or password";
+    }
+}
+?>
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Login - Forum</title>
+    <link rel="stylesheet" href="login.css">
+</head>
+<body>
+    <div class="login-container">
+        <h1>Forum Login</h1>
+        <?php if ($message): ?>
+            <p class="message"><?= $message ?></p>
+        <?php endif; ?>
+        <form action="login.php" method="post">
+            <div class="form-group">
+                <label for="username">Username</label>
+                <input type="text" id="username" name="username" required>
+            </div>
+            <div class="form-group">
+                <label for="password">Password</label>
+                <input type="password" id="password" name="password" required>
+            </div>
+            <button type="submit">Login</button>
+        </form>
+        <div class="signup-link">
+            <p>Don't have an account? <a href="signup.php">Sign up</a></p>
+        </div>
+    </div>
+</body>
+</html>

--- a/NotionForum/logout.php
+++ b/NotionForum/logout.php
@@ -1,0 +1,6 @@
+<?php
+session_start();
+session_unset();
+session_destroy();
+header("Location: index.php");
+exit();

--- a/NotionForum/notion_forum_db.sql
+++ b/NotionForum/notion_forum_db.sql
@@ -1,0 +1,52 @@
+CREATE DATABASE IF NOT EXISTS forum_db;
+
+USE forum_db;
+
+CREATE TABLE IF NOT EXISTS user (
+    user_id INT PRIMARY KEY NOT NULL AUTO_INCREMENT,
+    user_name VARCHAR(100) NOT NULL UNIQUE,
+    pass VARCHAR(100) NOT NULL,
+    user_type VARCHAR(20)
+);
+
+CREATE TABLE IF NOT EXISTS posts (
+    post_id INT PRIMARY KEY AUTO_INCREMENT,
+    title TEXT NOT NULL,
+    content TEXT NOT NULL,
+    post_type ENUM('BULLETIN', 'FORUM') NOT NULL,
+    category VARCHAR(20) NOT NULL,
+    img_name TEXT,
+    author_id INT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (author_id) REFERENCES user(user_id)
+);
+
+CREATE TABLE IF NOT EXISTS replies (
+    reply_id INT PRIMARY KEY AUTO_INCREMENT,
+    post_id INT NOT NULL,
+    content TEXT NOT NULL,
+    author_id INT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (post_id) REFERENCES posts(post_id) ON DELETE CASCADE,
+    FOREIGN KEY (author_id) REFERENCES user(user_id)
+);
+
+-- Insert default admin user
+INSERT INTO user (user_name, pass, user_type) VALUES ('uoc', 'uoc', 'ADMIN');
+
+-- Insert sample member user for testing
+INSERT INTO user (user_name, pass, user_type) VALUES ('testuser', 'password', 'MEMBER');
+
+-- Insert sample bulletin posts
+INSERT INTO posts (title, content, post_type, category, author_id) VALUES 
+('Welcome to the Community Bulletin', 'This is our new community bulletin system where you can share announcements and participate in discussions.', 'BULLETIN', 'General', 1),
+('Upcoming Community Event', 'Join us for our monthly community gathering this Saturday at 2 PM in the main hall.', 'BULLETIN', 'Events', 1);
+
+-- Insert sample forum post
+INSERT INTO posts (title, content, post_type, category, author_id) VALUES 
+('General Discussion: Community Guidelines', 'Let us discuss what guidelines we should have for our community forum. Please share your thoughts!', 'FORUM', 'Discussions', 1);
+
+-- Insert sample reply
+INSERT INTO replies (post_id, content, author_id) VALUES 
+(3, 'I think we should keep discussions respectful and on-topic. What do others think?', 2);

--- a/NotionForum/signup.php
+++ b/NotionForum/signup.php
@@ -1,0 +1,83 @@
+
+<?php
+session_start();
+
+require 'connector.php';
+
+$message = '';
+
+if ($_SERVER["REQUEST_METHOD"] == "POST") {
+    $username = $_POST['username'];
+    $password = $_POST['password'];
+    $confirm_password = $_POST['confirm_password'];
+
+    if ($password !== $confirm_password) {
+        $message = "Passwords do not match!";
+    } else {
+        // Check if username already exists
+        $sql = "SELECT user_id FROM user WHERE user_name = ?";
+        $stmt = $conn->prepare($sql);
+        $stmt->bind_param("s", $username);
+        $stmt->execute();
+        $result = $stmt->get_result();
+
+        if ($result->num_rows > 0) {
+            $message = "Username already taken!";
+        } else {
+            // Insert new user (default to MEMBER type)
+            $user_type = 'MEMBER';
+            $sql = "INSERT INTO user (user_name, pass, user_type) VALUES (?, ?, ?)";
+            $stmt = $conn->prepare($sql);
+            $stmt->bind_param("sss", $username, $password, $user_type);
+
+            if ($stmt->execute()) {
+                // Log the user in and redirect to home page (app.php)
+                $new_user_id = $conn->insert_id;
+                $_SESSION['user_id'] = $new_user_id;
+                $_SESSION['user_name'] = $username;
+                $_SESSION['user_type'] = $user_type;
+                header("Location: app.php");
+                exit();
+            } else {
+                $message = "Error: Could not create account.";
+            }
+        }
+    }
+}
+?>
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sign Up - Forum</title>
+    <link rel="stylesheet" href="login.css">
+</head>
+<body>
+    <div class="login-container">
+        <h1>Create an Account</h1>
+        <?php if ($message): ?>
+            <p class="message"><?= $message ?></p>
+        <?php endif; ?>
+        <form action="signup.php" method="post">
+            <div class="form-group">
+                <label for="username">Username</label>
+                <input type="text" id="username" name="username" required>
+            </div>
+            <div class="form-group">
+                <label for="password">Password</label>
+                <input type="password" id="password" name="password" required>
+            </div>
+            <div class="form-group">
+                <label for="confirm_password">Confirm Password</label>
+                <input type="password" id="confirm_password" name="confirm_password" required>
+            </div>
+            <button type="submit">Sign Up</button>
+        </form>
+        <div class="signup-link">
+            <p>Already have an account? <a href="login.php">Login</a></p>
+        </div>
+    </div>
+</body>
+</html>

--- a/NotionForum/styles.css
+++ b/NotionForum/styles.css
@@ -1,0 +1,514 @@
+
+:root {
+    --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    --bg-color: #FFFFFF;
+    --bg-secondary-color: #F7F7F7;
+    --border-color: #E5E5E5;
+    --text-color: #333333;
+    --text-secondary-color: #888888;
+    --accent-color: #2E6DA4;
+}
+
+body {
+    font-family: var(--font-sans);
+    background-color: var(--bg-secondary-color);
+    color: var(--text-color);
+    margin: 0;
+}
+
+.top-nav {
+    background-color: var(--bg-color);
+    border-bottom: 1px solid var(--border-color);
+    padding: 0 40px;
+}
+
+.nav-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    max-width: 1200px;
+    margin: 0 auto;
+    height: 60px;
+}
+
+.nav-brand {
+    font-size: 1.2em;
+    font-weight: 600;
+    color: var(--text-color);
+    text-decoration: none;
+}
+
+.nav-links, .nav-user {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    align-items: center;
+}
+
+.nav-links li a {
+    display: block;
+    padding: 22px 15px;
+    text-decoration: none;
+    color: var(--text-secondary-color);
+    border-bottom: 2px solid transparent;
+}
+
+.nav-links li a:hover {
+    color: var(--text-color);
+}
+
+.nav-links li a.active {
+    color: var(--text-color);
+    border-bottom: 2px solid var(--accent-color);
+}
+
+.nav-user li a {
+    color: var(--text-secondary-color);
+    text-decoration: none;
+    font-size: 0.9em;
+    padding: 10px;
+}
+
+.nav-user li .btn-signup {
+    background-color: var(--accent-color);
+    color: white;
+    border-radius: 5px;
+    padding: 10px 15px;
+}
+
+.nav-user li .btn-signup:hover {
+    background-color: #204d74;
+}
+
+.main-container {
+    padding: 40px;
+}
+
+.container {
+    max-width: 900px;
+    margin: 0 auto;
+    background-color: var(--bg-color);
+    padding: 40px;
+    border-radius: 8px;
+    border: 1px solid var(--border-color);
+}
+
+h1 {
+    font-size: 2em;
+    margin-bottom: 20px;
+}
+
+.page-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 20px;
+}
+
+.btn-create {
+    padding: 10px 15px;
+    background-color: var(--accent-color);
+    color: white;
+    text-decoration: none;
+    border-radius: 5px;
+    font-size: 0.9em;
+}
+
+.btn-create:hover {
+    background-color: #204d74;
+}
+
+/* Filter Bar */
+.filter-bar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 30px;
+    flex-wrap: wrap;
+    gap: 20px;
+}
+
+input[type="text"], input[type="password"] {
+    width: 100%;
+    padding: 10px;
+    border: 1px solid var(--border-color);
+    border-radius: 5px;
+    box-sizing: border-box; /* Important */
+}
+
+.search-form {
+    display: flex;
+}
+
+.search-form input[type="text"] {
+    min-width: 250px;
+    padding: 8px 12px;
+    border: 1px solid var(--border-color);
+    border-radius: 5px 0 0 5px;
+    font-size: 0.9em;
+}
+
+.search-form button {
+    padding: 8px 15px;
+    border: 1px solid var(--accent-color);
+    background-color: var(--accent-color);
+    color: white;
+    border-radius: 0 5px 5px 0;
+    cursor: pointer;
+}
+
+.category-pills {
+    display: flex;
+    gap: 10px;
+}
+
+.category-pills a {
+    display: block;
+    padding: 8px 15px;
+    border-radius: 20px;
+    background-color: var(--bg-secondary-color);
+    color: var(--text-secondary-color);
+    text-decoration: none;
+    font-size: 0.9em;
+    transition: all 0.2s ease;
+}
+
+.category-pills a:hover {
+    background-color: #e0e0e0;
+    color: var(--text-color);
+}
+
+.category-pills a.active {
+    background-color: var(--accent-color);
+    color: white;
+    font-weight: 500;
+}
+
+.posts-list {
+    display: grid;
+    gap: 20px;
+}
+
+.post-card {
+    background-color: var(--bg-color);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 20px;
+    transition: box-shadow 0.2s ease-in-out;
+}
+
+.post-card:hover {
+    box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+}
+
+/* Featured Posts */
+.featured-posts {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 20px;
+    margin-bottom: 30px;
+}
+
+.post-card.featured {
+    background-color: #fdfdfd;
+}
+
+
+.post-card h2 {
+    margin-top: 0;
+    font-size: 1.4em;
+}
+
+.post-card .post-meta {
+    font-size: 0.9em;
+    color: var(--text-secondary-color);
+    margin-bottom: 15px;
+}
+
+.post-card a {
+    color: var(--accent-color);
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.post-content-preview {
+    line-height: 1.6;
+    margin-bottom: 20px;
+}
+
+.card-replies {
+    border-top: 1px solid var(--border-color);
+    margin-top: 20px;
+    padding-top: 15px;
+}
+
+.mini-reply {
+    font-size: 0.9em;
+    background-color: var(--bg-secondary-color);
+    padding: 8px 12px;
+    border-radius: 5px;
+    margin-bottom: 8px;
+}
+
+.mini-reply p {
+    margin: 0;
+}
+
+.reply-form-inline {
+    display: flex;
+    margin-top: 15px;
+}
+
+.reply-form-inline input[type="text"] {
+    flex-grow: 1;
+    border: 1px solid var(--border-color);
+    border-radius: 5px 0 0 5px;
+    padding: 8px 10px;
+    font-size: 0.9em;
+}
+
+.reply-form-inline button {
+    padding: 8px 15px;
+    border: 1px solid var(--accent-color);
+    background-color: var(--accent-color);
+    color: white;
+    border-radius: 0 5px 5px 0;
+    cursor: pointer;
+    font-size: 0.9em;
+}
+
+/* Single Post View */
+.post-content {
+    line-height: 1.6;
+    font-size: 1.1em;
+}
+
+.post-divider {
+    border: 0;
+    border-top: 1px solid var(--border-color);
+    margin: 40px 0;
+}
+
+.replies-list {
+    display: grid;
+    gap: 15px;
+}
+
+.reply-card {
+    background-color: var(--bg-secondary-color);
+    border-radius: 8px;
+    padding: 15px 20px;
+}
+
+.reply-meta {
+    font-size: 0.9em;
+    margin-bottom: 5px;
+}
+
+.reply-meta strong {
+    color: var(--text-color);
+}
+
+.reply-meta .reply-date {
+    color: var(--text-secondary-color);
+}
+
+.reply-card p {
+    margin-top: 0;
+}
+
+/* Reply Form */
+.reply-form {
+    margin-top: 20px;
+    margin-bottom: 30px;
+}
+
+.reply-form textarea {
+    width: 100%;
+    min-height: 80px;
+    padding: 10px;
+    border: 1px solid var(--border-color);
+    border-radius: 5px;
+    box-sizing: border-box;
+    font-family: var(--font-sans);
+    font-size: 1em;
+    margin-bottom: 10px;
+}
+
+.reply-form button {
+    padding: 10px 15px;
+    background-color: var(--accent-color);
+    color: white;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 0.9em;
+}
+
+.reply-form button:hover {
+    background-color: #204d74;
+}
+
+/* Post Form */
+.post-form {
+    margin-top: 20px;
+}
+
+.post-form .form-group {
+    margin-bottom: 20px;
+}
+
+.post-form label {
+    display: block;
+    font-weight: 500;
+    margin-bottom: 8px;
+}
+
+.post-form input[type="text"],
+.post-form textarea {
+    width: 100%;
+    padding: 10px;
+    border: 1px solid var(--border-color);
+    border-radius: 5px;
+    box-sizing: border-box;
+    font-family: var(--font-sans);
+    font-size: 1em;
+}
+
+.post-form button {
+    padding: 10px 20px;
+    background-color: var(--accent-color);
+    color: white;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 1em;
+}
+
+.post-form button:hover {
+    background-color: #204d74;
+}
+
+.post-actions {
+    margin-top: 15px;
+    display: flex;
+    gap: 10px;
+}
+
+.post-action-btn {
+    display: inline-block;
+    padding: 5px 10px;
+    background-color: var(--bg-secondary-color);
+    color: var(--text-color);
+    text-decoration: none;
+    border-radius: 4px;
+    font-size: 0.85em;
+    border: 1px solid var(--border-color);
+}
+
+.post-action-btn:hover {
+    background-color: #e0e0e0;
+}
+
+.post-action-btn.btn-delete {
+    background-color: #f8d7da;
+    color: #721c24;
+    border-color: #f5c6cb;
+}
+
+.post-action-btn.btn-delete:hover {
+    background-color: #f5c6cb;
+}
+
+/* User Table */
+.user-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 20px;
+}
+
+.user-table th, .user-table td {
+    border: 1px solid var(--border-color);
+    padding: 12px 15px;
+    text-align: left;
+}
+
+.user-table thead {
+    background-color: var(--bg-secondary-color);
+}
+
+.user-table th {
+    font-weight: 600;
+}
+
+.user-table tbody tr:nth-of-type(even) {
+    background-color: var(--bg-secondary-color);
+}
+
+.user-table tbody tr:hover {
+    background-color: #e9e9e9;
+}
+
+.btn-action {
+    display: inline-block;
+    padding: 5px 10px;
+    background-color: var(--accent-color);
+    color: white;
+    text-decoration: none;
+    border-radius: 4px;
+    font-size: 0.85em;
+    margin-right: 5px;
+}
+
+.btn-action:hover {
+    background-color: #204d74;
+}
+
+.btn-delete {
+    background-color: #dc3545;
+}
+
+.btn-delete:hover {
+    background-color: #c82333;
+}
+
+/* User Form (for edit) */
+.user-form {
+    margin-top: 20px;
+}
+
+.user-form .form-group {
+    margin-bottom: 20px;
+}
+
+.user-form label {
+    display: block;
+    font-weight: 500;
+    margin-bottom: 8px;
+}
+
+.user-form input[type="text"],
+.user-form select {
+    width: 100%;
+    padding: 10px;
+    border: 1px solid var(--border-color);
+    border-radius: 5px;
+    box-sizing: border-box;
+    font-family: var(--font-sans);
+    font-size: 1em;
+}
+
+.user-form button {
+    padding: 10px 20px;
+    background-color: var(--accent-color);
+    color: white;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 1em;
+}
+
+.user-form button:hover {
+    background-color: #204d74;
+}

--- a/NotionForum/views/create_post.php
+++ b/NotionForum/views/create_post.php
@@ -1,0 +1,46 @@
+<?php
+// This file is views/create_post.php
+
+if (!isset($_SESSION['user_id']) || !in_array($_SESSION['user_type'], ['ADMIN', 'MEMBER'])) {
+    echo '<h1>Access Denied</h1>';
+    exit(); // Use exit() instead of break for included files
+}
+?>
+<h1>Create a New Post</h1>
+<form action="actions/create_post.php" method="POST" class="post-form">
+    <div class="form-group">
+        <label for="title">Title</label>
+        <input type="text" id="title" name="title" required>
+    </div>
+    <div class="form-group">
+        <label for="category">Category</label>
+        <select id="category" name="category" required>
+            <option value="">Select a category</option>
+            <?php foreach ($all_categories as $cat): ?>
+                <option value="<?= htmlspecialchars($cat) ?>"><?= htmlspecialchars($cat) ?></option>
+            <?php endforeach; ?>
+            <option value="Other">Other (specify below)</option>
+        </select>
+    </div>
+    <div class="form-group" id="new-category-group" style="display:none;">
+        <label for="new_category">New Category</label>
+        <input type="text" id="new_category" name="new_category">
+    </div>
+    <div class="form-group">
+        <label for="content">Content</label>
+        <textarea id="content" name="content" rows="10" required></textarea>
+    </div>
+    <button type="submit">Create Post</button>
+</form>
+<script>
+    document.getElementById('category').addEventListener('change', function() {
+        var newCategoryGroup = document.getElementById('new-category-group');
+        if (this.value === 'Other') {
+            newCategoryGroup.style.display = 'block';
+            document.getElementById('new_category').setAttribute('required', 'required');
+        } else {
+            newCategoryGroup.style.display = 'none';
+            document.getElementById('new_category').removeAttribute('required');
+        }
+    });
+</script>

--- a/NotionForum/views/edit_post.php
+++ b/NotionForum/views/edit_post.php
@@ -1,0 +1,72 @@
+<?php
+// This file is views/edit_post.php
+
+if (!isset($_SESSION['user_id'])) {
+    echo '<h1>Access Denied</h1>';
+    exit(); // Use exit() instead of break for included files
+}
+require 'connector.php';
+$post_id = $_GET['id'] ?? 0;
+$post_data = null;
+
+if ($post_id > 0) {
+    $sql = "SELECT title, content, category, author_id FROM posts WHERE post_id = ?";
+    $stmt = $conn->prepare($sql);
+    $stmt->bind_param("i", $post_id);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    if ($result->num_rows == 1) {
+        $post_data = $result->fetch_assoc();
+        // Check if user is author or admin
+        if ($post_data['author_id'] != $_SESSION['user_id'] && $_SESSION['user_type'] !== 'ADMIN') {
+            echo '<h1>Access Denied</h1>';
+            exit(); // Use exit() instead of break for included files
+        }
+    }
+}
+
+if ($post_data) {
+    ?>
+    <h1>Edit Post: <?= htmlspecialchars($post_data['title']) ?></h1>
+    <form action="actions/update_post.php" method="POST" class="post-form">
+        <input type="hidden" name="post_id" value="<?= $post_id ">
+        <div class="form-group">
+            <label for="title">Title</label>
+            <input type="text" id="title" name="title" value="<?= htmlspecialchars($post_data['title']) ?>" required>
+        </div>
+        <div class="form-group">
+            <label for="content">Content</label>
+            <textarea id="content" name="content" rows="10" required><?= htmlspecialchars($post_data['content']) ?></textarea>
+        </div>
+        <div class="form-group">
+            <label for="category">Category</label>
+            <select id="category" name="category" required>
+                <option value="">Select a category</option>
+                <?php foreach ($all_categories as $cat): ?>
+                    <option value="<?= htmlspecialchars($cat) ?>" <?= ($post_data['category'] === $cat ? 'selected' : '') ?>><?= htmlspecialchars($cat) ?></option>
+                <?php endforeach; ?>
+                <option value="Other" <?= (!in_array($post_data['category'], $all_categories) ? 'selected' : '') ?>>Other (specify below)</option>
+            </select>
+        </div>
+        <div class="form-group" id="new-category-group" style="display:<?= (!in_array($post_data['category'], $all_categories) ? 'block' : 'none') ?>;">
+            <label for="new_category">New Category</label>
+            <input type="text" id="new_category" name="new_category" value="<?= (!in_array($post_data['category'], $all_categories) ? htmlspecialchars($post_data['category']) : '') ?>">
+        </div>
+        <button type="submit">Update Post</button>
+    </form>
+    <script>
+        document.getElementById('category').addEventListener('change', function() {
+            var newCategoryGroup = document.getElementById('new-category-group');
+            if (this.value === 'Other') {
+                newCategoryGroup.style.display = 'block';
+                document.getElementById('new_category').setAttribute('required', 'required');
+            } else {
+                newCategoryGroup.style.display = 'none';
+                document.getElementById('new_category').removeAttribute('required');
+            }
+        });
+    </script>
+    <?php
+} else {
+    echo '<h1>Post not found.</h1>';
+}

--- a/NotionForum/views/edit_profile.php
+++ b/NotionForum/views/edit_profile.php
@@ -1,0 +1,43 @@
+<?php
+// This file is views/edit_profile.php
+
+if (!isset($_SESSION['user_id'])) {
+    echo '<h1>Access Denied</h1>';
+    exit();
+}
+
+require 'connector.php';
+
+$user_id = $_SESSION['user_id'];
+$user_data = null;
+
+if ($user_id > 0) {
+    $sql = "SELECT user_id, user_name FROM user WHERE user_id = ?";
+    $stmt = $conn->prepare($sql);
+    $stmt->bind_param("i", $user_id);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    if ($result->num_rows == 1) {
+        $user_data = $result->fetch_assoc();
+    }
+}
+
+if ($user_data) {
+    ?>
+    <h1>Edit Your Profile</h1>
+    <form action="actions/update_profile.php" method="POST" class="user-form">
+        <input type="hidden" name="user_id" value="<?= htmlspecialchars($user_data['user_id']) ?>">
+        <div class="form-group">
+            <label for="username">Username</label>
+            <input type="text" id="username" name="user_name" value="<?= htmlspecialchars($user_data['user_name']) ?>" required>
+        </div>
+        <div class="form-group">
+            <label for="password">New Password (leave blank to keep current)</label>
+            <input type="password" id="password" name="password">
+        </div>
+        <button type="submit">Update Profile</button>
+    </form>
+    <?php
+} else {
+    echo '<h1>User not found.</h1>';
+}

--- a/NotionForum/views/edit_user.php
+++ b/NotionForum/views/edit_user.php
@@ -1,0 +1,44 @@
+<?php
+// This file is views/edit_user.php
+
+if (!isset($_SESSION['user_type']) || $_SESSION['user_type'] !== 'ADMIN') {
+    echo '<h1>Access Denied</h1>';
+    exit(); // Use exit() instead of break for included files
+}
+require 'connector.php';
+$user_id = $_GET['id'] ?? 0;
+$user_data = null;
+
+if ($user_id > 0) {
+    $sql = "SELECT user_id, user_name, user_type FROM user WHERE user_id = ?";
+    $stmt = $conn->prepare($sql);
+    $stmt->bind_param("i", $user_id);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    if ($result->num_rows == 1) {
+        $user_data = $result->fetch_assoc();
+    }
+}
+
+if ($user_data) {
+    ?>
+    <h1>Edit User</h1>
+    <form action="actions/update_user.php" method="POST" class="user-form">
+        <input type="hidden" name="user_id" value="<?= htmlspecialchars($user_data['user_id']) ?>">
+        <div class="form-group">
+            <label for="username">Username</label>
+            <input type="text" id="username" name="user_name" value="<?= htmlspecialchars($user_data['user_name']) ?>" required>
+        </div>
+        <div class="form-group">
+            <label for="user_type">User Type</label>
+            <select id="user_type" name="user_type">
+                <option value="ADMIN" <?= ($user_data['user_type'] === 'ADMIN' ? 'selected' : '') ?>>ADMIN</option>
+                <option value="MEMBER" <?= ($user_data['user_type'] === 'MEMBER' ? 'selected' : '') ?>>MEMBER</option>
+            </select>
+        </div>
+        <button type="submit">Update User</button>
+    </form>
+    <?php
+} else {
+    echo '<h1>User not found.</h1>';
+}

--- a/NotionForum/views/post.php
+++ b/NotionForum/views/post.php
@@ -1,0 +1,57 @@
+<?php
+// This file is views/post.php
+
+require 'connector.php';
+$post_id = $_GET['id'] ?? 0;
+
+// Fetch the post
+$sql_post = "SELECT p.title, p.content, p.created_at, u.user_name FROM posts p JOIN user u ON p.author_id = u.user_id WHERE p.post_id = ?";
+$stmt_post = $conn->prepare($sql_post);
+$stmt_post->bind_param("i", $post_id);
+$stmt_post->execute();
+$result_post = $stmt_post->get_result();
+
+if ($result_post->num_rows == 1) {
+    $post = $result_post->fetch_assoc();
+    echo '<a href="app.php?view=posts">&larr; Back to Posts</a>';
+    echo '<h1>' . htmlspecialchars($post['title']) . '</h1>';
+    echo '<p class="post-meta">By ' . htmlspecialchars($post['user_name']) . ' on ' . date('F j, Y', strtotime($post['created_at'])) . '</p>';
+    echo '<div class="post-content">' . nl2br(htmlspecialchars($post['content'])) . '</div>';
+
+    // Fetch replies
+    $sql_replies = "SELECT r.content, r.created_at, u.user_name FROM replies r JOIN user u ON r.author_id = u.user_id WHERE r.post_id = ? ORDER BY r.created_at ASC";
+    $stmt_replies = $conn->prepare($sql_replies);
+    $stmt_replies->bind_param("i", $post_id);
+    $stmt_replies->execute();
+    $result_replies = $stmt_replies->get_result();
+
+    // Replies section
+    echo '<hr class="post-divider">';
+    echo '<h2>Replies</h2>';
+
+    if ($result_replies->num_rows > 0) {
+        echo '<div class="replies-list">';
+        while($reply = $result_replies->fetch_assoc()) {
+            echo '<div class="reply-card">';
+            echo '<p class="reply-meta"><strong>' . htmlspecialchars($reply['user_name']) . '</strong><span class="reply-date"> on ' . date('F j, Y', strtotime($reply['created_at'])) . '</span></p>';
+            echo '<p>' . nl2br(htmlspecialchars($reply['content'])) . '</p>';
+            echo '</div>';
+        }
+        echo '</div>';
+    } else {
+        echo '<p>No replies yet.</p>';
+    }
+    
+    if (isset($_SESSION['user_id'])) {
+        echo '<form action="actions/add_reply.php" method="POST" class="reply-form">';
+        echo '    <input type="hidden" name="post_id" value="' . htmlspecialchars($post_id) . '">';
+        echo '    <textarea name="reply_content" placeholder="Write a reply..." required></textarea>';
+        echo '    <button type="submit">Post</button>';
+        echo '</form>';
+    } else {
+        echo '<p><a href="login.php">Log in</a> to leave a reply.</p>';
+    }
+
+} else {
+    echo '<h1>Post not found</h1>';
+}

--- a/NotionForum/views/posts.php
+++ b/NotionForum/views/posts.php
@@ -1,0 +1,94 @@
+<?php
+// This file is views/posts.php
+
+echo '<div class="page-header">';
+echo '<h1>Posts</h1>';
+if (isset($_SESSION['user_type']) && in_array($_SESSION['user_type'], ['ADMIN', 'MEMBER'])) {
+    echo '<a href="app.php?view=create_post" class="btn-create">New Post</a>';
+}
+echo '</div>';
+
+require 'connector.php';
+
+// Fetch categories for filter pills
+$categories_sql = "SELECT DISTINCT category FROM posts ORDER BY category ASC";
+$categories_result = $conn->query($categories_sql);
+$current_category = $_GET['category'] ?? 'All';
+$search_term = $_GET['search'] ?? '';
+
+// --- Filter Bar (Search and Categories) ---
+echo '<div class="filter-bar">';
+// Search Form
+echo '<form action="app.php" method="GET" class="search-form">';
+echo '    <input type="hidden" name="view" value="posts">';
+echo '    <input type="text" name="search" placeholder="Search posts..." value="' . htmlspecialchars($search_term) . '">';
+echo '    <button type="submit">Search</button>';
+echo '</form>';
+
+// Category Pills
+echo '<div class="category-pills">';
+echo '<a href="app.php?view=posts" class="' . ($current_category === 'All' ? 'active' : '') . '">All</a>';
+if ($categories_result->num_rows > 0) {
+    while($cat_row = $categories_result->fetch_assoc()) {
+        $category = htmlspecialchars($cat_row['category']);
+        echo '<a href="app.php?view=posts&category=' . urlencode($category) . '" class="' . ($current_category === $category ? 'active' : '') . '">' . $category . '</a>';
+    }
+}
+echo '</div>';
+echo '</div>';
+
+
+// --- Fetch Posts (with filtering) ---
+$sql = "SELECT p.post_id, p.title, p.content, p.created_at, p.author_id, u.user_name FROM posts p JOIN user u ON p.author_id = u.user_id";
+$params = [];
+$types = '';
+
+$where_clauses = [];
+if ($current_category !== 'All') {
+    $where_clauses[] = "p.category = ?";
+    $params[] = $current_category;
+    $types .= 's';
+}
+if (!empty($search_term)) {
+    $where_clauses[] = "(p.title LIKE ? OR p.content LIKE ?)";
+    $search_param = "%{$search_term}%";
+    $params[] = $search_param;
+    $params[] = $search_param;
+    $types .= 'ss';
+}
+
+if (!empty($where_clauses)) {
+    $sql .= " WHERE " . implode(' AND ', $where_clauses);
+}
+
+$sql .= " ORDER BY p.created_at DESC";
+
+$stmt = $conn->prepare($sql);
+if (!empty($params)) {
+    $stmt->bind_param($types, ...$params);
+}
+$stmt->execute();
+$result = $stmt->get_result();
+
+if ($result->num_rows > 0) {
+    echo '<div class="posts-list">';
+    while($row = $result->fetch_assoc()) {
+        echo '<div class="post-card">';
+        echo '<h2>' . htmlspecialchars($row['title']) . '</h2>';
+        echo '<p class="post-meta">By ' . htmlspecialchars($row['user_name']) . ' on ' . date('F j, Y', strtotime($row['created_at'])) . '</p>';
+        echo '<p>' . nl2br(htmlspecialchars(substr($row['content'], 0, 150))) . '...</p>';
+        echo '<a href="app.php?view=post&id=' . $row['post_id'] . '" class="btn-reply">View Post</a>';
+        
+        // Edit/Delete buttons for author/admin
+        if (isset($_SESSION['user_id']) && ($_SESSION['user_id'] == $row['author_id'] || $_SESSION['user_type'] === 'ADMIN')) {
+            echo '<div class="post-actions">';
+            echo '<a href="app.php?view=edit_post&id=' . $row['post_id'] . '" class="post-action-btn">Edit</a>';
+            echo '<a href="actions/delete_post.php?id=' . $row['post_id'] . '" class="post-action-btn btn-delete" onclick="return confirm(\'Are you sure you want to delete this post?\');">Delete</a>';
+            echo '</div>';
+        }
+        echo '</div>';
+    }
+    echo '</div>';
+} else {
+    echo '<p>No posts found.</p>';
+}

--- a/NotionForum/views/users.php
+++ b/NotionForum/views/users.php
@@ -1,0 +1,35 @@
+<?php
+// This file is views/users.php
+
+// Check for admin privileges
+if (isset($_SESSION['user_type']) && $_SESSION['user_type'] === 'ADMIN') {
+    echo '<h1>Manage Users</h1>';
+    
+    require 'connector.php';
+    $sql = "SELECT user_id, user_name, user_type FROM user";
+    $result = $conn->query($sql);
+
+    if ($result->num_rows > 0) {
+        echo '<table class="user-table">';
+        echo '<thead><tr><th>ID</th><th>Username</th><th>Role</th><th>Actions</th></tr></thead>';
+        echo '<tbody>';
+        while($row = $result->fetch_assoc()) {
+            echo '<tr>';
+            echo '<td>' . $row['user_id'] . '</td>';
+            echo '<td>' . htmlspecialchars($row['user_name']) . '</td>';
+            echo '<td>' . htmlspecialchars($row['user_type']) . '</td>';
+            echo '<td>';
+            echo '<a href="app.php?view=edit_user&id=' . $row['user_id'] . '" class="btn-action">Edit</a> ';
+            echo '<a href="actions/delete_user.php?id=' . $row['user_id'] . '" class="btn-action btn-delete" onclick="return confirm(\'Are you sure you want to delete this user?\');">Delete</a>';
+            echo '</td>';
+            echo '</tr>';
+        }
+        echo '</tbody>';
+        echo '</table>';
+    } else {
+        echo '<p>No users found.</p>';
+    }
+
+} else {
+    echo '<h1>Access Denied</h1>';
+}


### PR DESCRIPTION
Add server-side actions and view templates to support core forum operations: creating posts, deleting users, viewing individual posts with replies, and editing user profiles.

- actions_post.php: add POST handler to insert new posts, support custom "Other" category and restrict creation to ADMIN and MEMBER users; redirect to posts view after creation.
- actions/delete_user.php: add delete action that allows ADMIN users to remove a user by id and then redirects to the users view.
- views/post.php: add post view to display a single post with author, formatted date, content, and an ordered list of replies; include a reply form for logged-in users.
- views/edit_profile.php: add profile edit form populated from the current session user; allow username changes and optional password update.

These changes implement basic CRUD flows for posts and user profile management and provide an entry point for replying to posts. Input is minimally validated and actions require session-based permissions.